### PR TITLE
메인 페이지 레이아웃 구현

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -4,6 +4,14 @@
 
 @layer base {
   :root {
-    @apply font-pretendard m-0 box-border p-0 tracking-tight;
+    @apply m-0 box-border p-0 font-pretendard tracking-tight;
+  }
+
+  * {
+    -ms-overflow-style: none;
+  }
+
+  *::-webkit-scrollbar {
+    display: none;
   }
 }

--- a/src/layouts/AppLayout.tsx
+++ b/src/layouts/AppLayout.tsx
@@ -1,0 +1,13 @@
+import { Outlet } from 'react-router-dom';
+
+export default function AppLayout() {
+  return (
+    <div className="flex h-full flex-col">
+      <header className="border border-red-300">헤더</header>
+      <main className="scroll min-h-1 flex-1 overflow-y-scroll border border-blue-300 p-5">
+        <Outlet />
+      </main>
+      <footer className="border border-green-500">풋터</footer>
+    </div>
+  );
+}

--- a/src/layouts/RootLayout.tsx
+++ b/src/layouts/RootLayout.tsx
@@ -2,8 +2,8 @@ import { Outlet } from 'react-router-dom';
 
 export default function RootLayout() {
   return (
-    <main className="mx-auto min-h-dvh w-full border-x md:max-w-[48rem]">
+    <div className="mx-auto h-1 min-h-dvh w-full border-x md:max-w-[48rem]">
       <Outlet />
-    </main>
+    </div>
   );
 }

--- a/src/pages/Root/page.tsx
+++ b/src/pages/Root/page.tsx
@@ -24,7 +24,6 @@ export async function loader({ request }: LoaderFunctionArgs) {
 
 export default function Page() {
   const isAuthenticated = useIsAuthenticated();
-  const user = useUser();
 
   const { status, payload } = useLoaderData() as Awaited<ReturnType<typeof loader>>;
   const { signIn } = useAuthActions();
@@ -46,10 +45,5 @@ export default function Page() {
 
   clearSearchParams();
 
-  return (
-    <>
-      {user?.accountId}어서오시오. 메인이오.
-      <Link to="/auth/signout">로그아웃</Link>
-    </>
-  );
+  return <Navigate to="/vote-fap" />;
 }

--- a/src/pages/Root/voteFAP/page.tsx
+++ b/src/pages/Root/voteFAP/page.tsx
@@ -1,0 +1,12 @@
+export default function Page() {
+  return (
+    <>
+      투표 화면
+      <ul className="flex flex-col gap-6">
+        {[1, 2, 3, 4, 5].map((_, index) => (
+          <li key={index} className="aspect-[3/4] w-full rounded-lg bg-gray-100" />
+        ))}
+      </ul>
+    </>
+  );
+}

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -12,10 +12,12 @@ import ProtectedRoute from './ProtectedRoute';
 /** Common */
 const NotFoundPage = lazy(() => import('@Pages/NotFoundPage'));
 const GlobalErrorPage = lazy(() => import('@Pages/GlobalErrorPage').then((module) => ({ default: module.default })));
+const AppLayout = lazy(() => import('@Layouts/AppLayout').then((module) => ({ default: module.default })));
 
 /** Root */
 const LoginPage = lazy(() => import('@Pages/Root/Login/page').then((module) => ({ default: module.default })));
 const InitializeAccountPage = lazy(() => import('@Pages/Root/InitializeAccount/page').then((module) => ({ default: module.default })));
+const VoteFAPPage = lazy(() => import('@Pages/Root/voteFAP/page').then((module) => ({ default: module.default })));
 
 /** Auth */
 const KakaoCallback = lazy(() => import('@Pages/Auth/KakaoCallback').then((module) => ({ default: module.default })));
@@ -28,11 +30,13 @@ export const routesFromElements = createRoutesFromElements(
       <Route path="login" element={<LoginPage />} />
       <Route path="initialize-account" element={<InitializeAccountPage />} />
       <Route element={<ProtectedRoute />}>
-        <Route path="archive" />
-        <Route path="fap" />
-        <Route path="upload" />
-        <Route path="feed" />
-        <Route path="mypage" />
+        <Route element={<AppLayout />}>
+          <Route path="archive" />
+          <Route path="vote-fap" element={<VoteFAPPage />} />
+          <Route path="upload" />
+          <Route path="feed" />
+          <Route path="mypage" />
+        </Route>
       </Route>
     </Route>
 


### PR DESCRIPTION
### 관련된 이슈 번호를 기입해주세요.
> `close #이슈번호` 와 같은 형식으로 작성해주세요.

- close #26 

### 어떤 부분이 변경됐나요?
> 어떤 부분을 변경했는지, 무슨 이유로 코드를 변경했는지 설명해주세요.

- 서비스 공통 레이아웃을 작성했습니다(AppLayout)
- 헤더, 바디, 풋터로 이루어져 있습니다.
- 항상 부모의 height를 전부 채우고, 바디가 자리를 최대한 차지합니다.
- 바디 안의 내용이 바디를 넘어설 때, Overflow를 적용합니다.

### 추가 정보 (선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.

![GIF 2024-07-06 오전 12-03-00](https://github.com/swyp-fade/fade-frontend/assets/48979587/a4f95b35-aa9d-4ac4-bfe2-0a29c5d5c92d)
