### PR TITLE
공통 레이아웃 UI 구현

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-hook-form": "^7.52.1",
+    "react-icons": "^5.2.1",
     "react-router-dom": "^6.24.0",
     "tailwind-merge": "^2.3.0",
     "zod": "^3.23.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,6 +44,9 @@ importers:
       react-hook-form:
         specifier: ^7.52.1
         version: 7.52.1(react@18.3.1)
+      react-icons:
+        specifier: ^5.2.1
+        version: 5.2.1(react@18.3.1)
       react-router-dom:
         specifier: ^6.24.0
         version: 6.24.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -1620,6 +1623,11 @@ packages:
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17 || ^18 || ^19
+
+  react-icons@5.2.1:
+    resolution: {integrity: sha512-zdbW5GstTzXaVKvGSyTaBalt7HSfuK5ovrzlpyiWHAFXndXTdd/1hdDHI4xBM1Mn7YriT6aqESucFl9kEXzrdw==}
+    peerDependencies:
+      react: '*'
 
   react-router-dom@6.24.0:
     resolution: {integrity: sha512-960sKuau6/yEwS8e+NVEidYQb1hNjAYM327gjEyXlc6r3Skf2vtwuJ2l7lssdegD2YjoKG5l8MsVyeTDlVeY8g==}
@@ -3259,6 +3267,10 @@ snapshots:
       scheduler: 0.23.2
 
   react-hook-form@7.52.1(react@18.3.1):
+    dependencies:
+      react: 18.3.1
+
+  react-icons@5.2.1(react@18.3.1):
     dependencies:
       react: 18.3.1
 

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,11 +1,15 @@
-import { MdInfoOutline, MdOutlineNotificationsNone } from 'react-icons/md';
+import { useHeaderStore } from '@Stores/header';
 
 export function Header() {
+  const leftSlot = useHeaderStore((state) => state.leftSlot);
+  const rightSlot = useHeaderStore((state) => state.rightSlot);
+  const title = useHeaderStore((state) => state.title);
+
   return (
     <header className="relative px-5 py-4">
-      <MdInfoOutline className="absolute left-5 top-1/2 size-6 -translate-y-1/2" />
-      <p className="text-center text-2xl font-semibold">FA:P 투표</p>
-      <MdOutlineNotificationsNone className="absolute right-5 top-1/2 size-6 -translate-y-1/2" />
+      {leftSlot && <div className="absolute left-5 top-1/2 -translate-y-1/2">{leftSlot()}</div>}
+      {title && <p className="text-center text-2xl font-semibold">{title}</p>}
+      {rightSlot && <div className="absolute right-5 top-1/2 -translate-y-1/2">{rightSlot()}</div>}
     </header>
   );
 }

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,0 +1,11 @@
+import { MdInfoOutline, MdOutlineNotificationsNone } from 'react-icons/md';
+
+export function Header() {
+  return (
+    <header className="relative px-5 py-4">
+      <MdInfoOutline className="absolute left-5 top-1/2 size-6 -translate-y-1/2" />
+      <p className="text-center text-2xl font-semibold">FA:P 투표</p>
+      <MdOutlineNotificationsNone className="absolute right-5 top-1/2 size-6 -translate-y-1/2" />
+    </header>
+  );
+}

--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -1,8 +1,7 @@
 import { cn } from '@Utils/index';
-import { useCallback } from 'react';
 import { IconType } from 'react-icons/lib';
 import { MdAccountBox, MdAdd, MdHowToVote, MdOutlineGridOn, MdPerson } from 'react-icons/md';
-import { NavLink } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 
 interface NavItem {
   link: string;
@@ -33,29 +32,31 @@ const navList: NavItem[] = [
 ];
 
 export function NavBar() {
-  const memoizedCreateNavItem = useCallback((navItem: NavItem) => <NavItem key={navItem.link} {...navItem} />, []);
+  const location = useLocation();
+  const createNavItem = (navItem: NavItem) => <NavItem key={navItem.link} {...navItem} isActive={location.pathname.startsWith(navItem.link)} />;
 
   return (
     <nav>
-      <ul className="flex flex-row">{navList.map(memoizedCreateNavItem)}</ul>
+      <ul className="flex flex-row">{navList.map(createNavItem)}</ul>
     </nav>
   );
 }
 
-type NavItemProps = { link: string; IconComponent: IconType };
+type NavItemProps = { link: string; IconComponent: IconType; isActive: boolean };
 
-function NavItem({ link, IconComponent }: NavItemProps) {
+function NavItem({ link, IconComponent, isActive }: NavItemProps) {
+  const navigate = useNavigate();
+
   return (
     <li className="flex-1">
-      <NavLink
-        to={link}
-        className={({ isActive }) =>
-          cn('block h-full w-full py-5 transition-transform hover:rotate-3 hover:scale-125 active:scale-95', {
-            ['text-purple-700']: isActive,
-          })
-        }>
+      <button
+        type="button"
+        className={cn('pointerdevice:hover:rotate-3 pointerdevice:hover:scale-125 pointerdevice:active:scale-95 block h-full w-full py-5 transition-transform', {
+          ['text-purple-700']: isActive,
+        })}
+        onClick={() => navigate(link)}>
         <IconComponent className="mx-auto size-6" />
-      </NavLink>
+      </button>
     </li>
   );
 }

--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -1,36 +1,61 @@
-import { MdOutlineGridOn, MdHowToVote, MdAdd, MdAccountBox, MdPerson } from 'react-icons/md';
-import { Link } from 'react-router-dom';
+import { cn } from '@Utils/index';
+import { useCallback } from 'react';
+import { IconType } from 'react-icons/lib';
+import { MdAccountBox, MdAdd, MdHowToVote, MdOutlineGridOn, MdPerson } from 'react-icons/md';
+import { NavLink } from 'react-router-dom';
+
+interface NavItem {
+  link: string;
+  IconComponent: IconType;
+}
+
+const navList: NavItem[] = [
+  {
+    link: '/archive',
+    IconComponent: MdOutlineGridOn,
+  },
+  {
+    link: '/vote-fap',
+    IconComponent: MdHowToVote,
+  },
+  {
+    link: '/upload',
+    IconComponent: MdAdd,
+  },
+  {
+    link: '/feed',
+    IconComponent: MdAccountBox,
+  },
+  {
+    link: '/mypage',
+    IconComponent: MdPerson,
+  },
+];
 
 export function NavBar() {
+  const memoizedCreateNavItem = useCallback((navItem: NavItem) => <NavItem key={navItem.link} {...navItem} />, []);
+
   return (
     <nav>
-      <ul className="flex flex-row">
-        <li className="flex-1">
-          <Link to="/archive" className="block h-full w-full py-5 transition-transform hover:rotate-3 hover:scale-125">
-            <MdOutlineGridOn className="mx-auto size-6" />
-          </Link>
-        </li>
-        <li className="flex-1">
-          <Link to="/archive" className="block h-full w-full py-5 transition-transform hover:rotate-3 hover:scale-125">
-            <MdHowToVote className="mx-auto size-6" />
-          </Link>
-        </li>
-        <li className="flex-1">
-          <Link to="/archive" className="block h-full w-full py-5 transition-transform hover:rotate-3 hover:scale-125">
-            <MdAdd className="mx-auto size-6" />
-          </Link>
-        </li>
-        <li className="flex-1">
-          <Link to="/archive" className="block h-full w-full py-5 transition-transform hover:rotate-3 hover:scale-125">
-            <MdAccountBox className="mx-auto size-6" />
-          </Link>
-        </li>
-        <li className="flex-1">
-          <Link to="/archive" className="block h-full w-full py-5 transition-transform hover:rotate-3 hover:scale-125">
-            <MdPerson className="mx-auto size-6" />
-          </Link>
-        </li>
-      </ul>
+      <ul className="flex flex-row">{navList.map(memoizedCreateNavItem)}</ul>
     </nav>
+  );
+}
+
+type NavItemProps = { link: string; IconComponent: IconType };
+
+function NavItem({ link, IconComponent }: NavItemProps) {
+  return (
+    <li className="flex-1">
+      <NavLink
+        to={link}
+        className={({ isActive }) =>
+          cn('block h-full w-full py-5 transition-transform hover:rotate-3 hover:scale-125 active:scale-95', {
+            ['text-purple-700']: isActive,
+          })
+        }>
+        <IconComponent className="mx-auto size-6" />
+      </NavLink>
+    </li>
   );
 }

--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -1,0 +1,36 @@
+import { MdOutlineGridOn, MdHowToVote, MdAdd, MdAccountBox, MdPerson } from 'react-icons/md';
+import { Link } from 'react-router-dom';
+
+export function NavBar() {
+  return (
+    <nav>
+      <ul className="flex flex-row">
+        <li className="flex-1">
+          <Link to="/archive" className="block h-full w-full py-5 transition-transform hover:rotate-3 hover:scale-125">
+            <MdOutlineGridOn className="mx-auto size-6" />
+          </Link>
+        </li>
+        <li className="flex-1">
+          <Link to="/archive" className="block h-full w-full py-5 transition-transform hover:rotate-3 hover:scale-125">
+            <MdHowToVote className="mx-auto size-6" />
+          </Link>
+        </li>
+        <li className="flex-1">
+          <Link to="/archive" className="block h-full w-full py-5 transition-transform hover:rotate-3 hover:scale-125">
+            <MdAdd className="mx-auto size-6" />
+          </Link>
+        </li>
+        <li className="flex-1">
+          <Link to="/archive" className="block h-full w-full py-5 transition-transform hover:rotate-3 hover:scale-125">
+            <MdAccountBox className="mx-auto size-6" />
+          </Link>
+        </li>
+        <li className="flex-1">
+          <Link to="/archive" className="block h-full w-full py-5 transition-transform hover:rotate-3 hover:scale-125">
+            <MdPerson className="mx-auto size-6" />
+          </Link>
+        </li>
+      </ul>
+    </nav>
+  );
+}

--- a/src/hooks/useHeader.ts
+++ b/src/hooks/useHeader.ts
@@ -1,0 +1,16 @@
+import { useHeaderStore } from '@Stores/header';
+import { ReactNode, useEffect } from 'react';
+
+type UseHeaderProps = { title?: string; leftSlot?: () => ReactNode; rightSlot?: () => ReactNode };
+
+export function useHeader({ title, leftSlot, rightSlot }: UseHeaderProps) {
+  const setTitle = useHeaderStore((state) => state.setTitle);
+  const setLeftSlot = useHeaderStore((state) => state.setLeftSlot);
+  const setRightSlot = useHeaderStore((state) => state.setRightSlot);
+
+  useEffect(() => {
+    setTitle(title);
+    setLeftSlot(leftSlot);
+    setRightSlot(rightSlot);
+  }, []);
+}

--- a/src/layouts/AppLayout.tsx
+++ b/src/layouts/AppLayout.tsx
@@ -1,13 +1,15 @@
+import { Header } from '@Components/Header';
+import { NavBar } from '@Components/NavBar';
 import { Outlet } from 'react-router-dom';
 
 export default function AppLayout() {
   return (
     <div className="flex h-full flex-col">
-      <header className="border border-red-300">헤더</header>
+      <Header />
       <main className="scroll min-h-1 flex-1 overflow-y-scroll border border-blue-300 p-5">
         <Outlet />
       </main>
-      <footer className="border border-green-500">풋터</footer>
+      <NavBar />
     </div>
   );
 }

--- a/src/pages/Root/voteFAP/page.tsx
+++ b/src/pages/Root/voteFAP/page.tsx
@@ -1,4 +1,14 @@
+import { useHeader } from '@Hooks/useHeader';
+import { useState } from 'react';
+import { MdInfoOutline, MdOutlineNotificationsNone } from 'react-icons/md';
+
 export default function Page() {
+  useHeader({
+    title: 'FA:P 투표',
+    leftSlot: () => <MdInfoOutline className="size-6" />,
+    rightSlot: () => <RightSlotComponent />,
+  });
+
   return (
     <>
       투표 화면
@@ -10,3 +20,20 @@ export default function Page() {
     </>
   );
 }
+
+/** Popover 테스트용으로 ㅎㅎ */
+const RightSlotComponent = () => {
+  const [isOpened, setIsOpened] = useState(false);
+
+  return (
+    <div className="relative" onClick={() => setIsOpened(!isOpened)}>
+      <MdOutlineNotificationsNone className="size-6" />
+
+      {isOpened && (
+        <div className="absolute right-4 top-full flex min-w-max rounded border bg-white p-5">
+          <p>흐으음..</p>
+        </div>
+      )}
+    </div>
+  );
+};

--- a/src/stores/header.ts
+++ b/src/stores/header.ts
@@ -1,0 +1,24 @@
+import { ReactNode } from 'react';
+import { create } from 'zustand';
+
+type SlotType = () => ReactNode;
+
+export type HeaderStore = {
+  title: string | undefined;
+  leftSlot: SlotType | undefined;
+  rightSlot: SlotType | undefined;
+
+  setTitle: (title: string | undefined) => void;
+  setLeftSlot: (slot: SlotType | undefined) => void;
+  setRightSlot: (slot: SlotType | undefined) => void;
+};
+
+export const useHeaderStore = create<HeaderStore>((set, get) => ({
+  title: undefined,
+  leftSlot: undefined,
+  rightSlot: undefined,
+
+  setTitle: (title) => set({ title }),
+  setLeftSlot: (leftSlot) => set({ leftSlot }),
+  setRightSlot: (rightSlot) => set({ rightSlot }),
+}));

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -3,6 +3,11 @@ export default {
   content: ['./index.html', './src/**/*.{js,ts,jsx,tsx}'],
   theme: {
     extend: {
+      screens: {
+        fullscreen: { raw: '(display-mode: fullscreen)' },
+        touchdevice: { raw: '(pointer: coarse)' },
+        pointerdevice: { raw: '(pointer: fine)' },
+      },
       fontFamily: {
         pretendard: ['Pretendard'],
       },


### PR DESCRIPTION
### 관련된 이슈 번호를 기입해주세요.
> `close #이슈번호` 와 같은 형식으로 작성해주세요.

- close #28 

### 어떤 부분이 변경됐나요?
> 어떤 부분을 변경했는지, 무슨 이유로 코드를 변경했는지 설명해주세요.

- Header Component를 작성했어요.
- Header를 페이지 별로 설정할 수 있도록 로직을 작성했어요.
  - header 상태를 전역 상태로 두고, 페이지 내부에서 `useHeader()`를 호출하여 설정해요.
  - Header Component에서는 전역 상태를 받아와서 렌더링해요.
- 기본 NavBar Component를 작성했어요.
  - 나중에 수정 및 확장이 편하도록 로직을 작성했어요.
  - 네비게이션 아이템 목록을 따로 작성하며, 해당 목록을 렌더링해요.
- 설명을 위해 FA:P 투표 화면 헤더와 FA:P 아카이브 화면 헤더를 설정해봤어요.
- 알림 느낌도 슬쩍~

![GIF 2024-07-07 오전 12-24-26](https://github.com/swyp-fade/fade-frontend/assets/48979587/c22d76ed-dbe2-411a-a12e-29c1e79c9a8b)


### 추가 정보 (선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.

- 처음에 NavBar 버튼을 `NavLink`로 작성했다가 Button을 통해 `navigate()`를 호출하는 방식으로 바꿨어요.
  - 사파리에서 테스트 도중, a 태그를 길게 누르면 나오는 미리보기를 방지하고 싶었어요.
  - `user-select`를 통해 막을 수는 있으나, 작은 정보가 뜨긴 하더라구요.
  - 그래서 그냥 Button으로 처리했어요.
    - 그렇게 되면 웹 크롤러가 경로를 수집하기 어렵겠지만, SEO가 중요한 서비스가 아니므로 적절할 것으로 판단했어요.
