### PR TITLE
기본 페이지 생성 및 라우팅 설정 보완

### DIFF
--- a/src/hooks/useHeader.ts
+++ b/src/hooks/useHeader.ts
@@ -1,5 +1,5 @@
 import { useHeaderStore } from '@Stores/header';
-import { ReactNode, useEffect } from 'react';
+import { ReactNode, useLayoutEffect } from 'react';
 
 type UseHeaderProps = { title?: string; leftSlot?: () => ReactNode; rightSlot?: () => ReactNode };
 
@@ -8,7 +8,7 @@ export function useHeader({ title, leftSlot, rightSlot }: UseHeaderProps) {
   const setLeftSlot = useHeaderStore((state) => state.setLeftSlot);
   const setRightSlot = useHeaderStore((state) => state.setRightSlot);
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     setTitle(title);
     setLeftSlot(leftSlot);
     setRightSlot(rightSlot);

--- a/src/layouts/AppLayout.tsx
+++ b/src/layouts/AppLayout.tsx
@@ -1,5 +1,6 @@
 import { Header } from '@Components/Header';
 import { NavBar } from '@Components/NavBar';
+import { Suspense } from 'react';
 import { Outlet } from 'react-router-dom';
 
 export default function AppLayout() {
@@ -7,7 +8,9 @@ export default function AppLayout() {
     <div className="flex h-full flex-col">
       <Header />
       <main className="scroll min-h-1 flex-1 overflow-y-scroll border border-blue-300 p-5">
-        <Outlet />
+        <Suspense fallback={<>페이지 로딩 중!</>}>
+          <Outlet />
+        </Suspense>
       </main>
       <NavBar />
     </div>

--- a/src/pages/Root/archive/page.tsx
+++ b/src/pages/Root/archive/page.tsx
@@ -1,0 +1,7 @@
+import { useHeader } from '@Hooks/useHeader';
+
+export default function Page() {
+  useHeader({ title: 'FA:P 아카이브' });
+
+  return <>아카이브 화면</>;
+}

--- a/src/pages/Root/feed/page.tsx
+++ b/src/pages/Root/feed/page.tsx
@@ -1,0 +1,7 @@
+import { useHeader } from '@Hooks/useHeader';
+
+export default function Page() {
+  useHeader({ title: '구독' });
+
+  return <>구독 페이지</>;
+}

--- a/src/pages/Root/mypage/page.tsx
+++ b/src/pages/Root/mypage/page.tsx
@@ -1,0 +1,7 @@
+import { useHeader } from '@Hooks/useHeader';
+
+export default function Page() {
+  useHeader({ title: '마이페이지' });
+
+  return <>마이 페이지</>;
+}

--- a/src/pages/Root/upload/page.tsx
+++ b/src/pages/Root/upload/page.tsx
@@ -1,0 +1,12 @@
+import { useHeader } from '@Hooks/useHeader';
+import { MdClose, MdOutlineInfo } from 'react-icons/md';
+
+export default function Page() {
+  useHeader({
+    title: '사진 업로드',
+    leftSlot: () => <MdClose className="size-6" />,
+    rightSlot: () => <MdOutlineInfo className="size-6" />,
+  });
+
+  return <>업로드 화면</>;
+}

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -1,6 +1,6 @@
 import RootLayout from '@Layouts/RootLayout';
 import RootPage from '@Pages/Root/page';
-import { lazy } from 'react';
+import { lazy, Suspense } from 'react';
 import { Route, createRoutesFromElements } from 'react-router-dom';
 import ProtectedRoute from './ProtectedRoute';
 
@@ -17,7 +17,11 @@ const AppLayout = lazy(() => import('@Layouts/AppLayout').then((module) => ({ de
 /** Root */
 const LoginPage = lazy(() => import('@Pages/Root/Login/page').then((module) => ({ default: module.default })));
 const InitializeAccountPage = lazy(() => import('@Pages/Root/InitializeAccount/page').then((module) => ({ default: module.default })));
+const ArchivePage = lazy(() => import('@Pages/Root/archive/page').then((module) => ({ default: module.default })));
 const VoteFAPPage = lazy(() => import('@Pages/Root/voteFAP/page').then((module) => ({ default: module.default })));
+const UploadPage = lazy(() => import('@Pages/Root/upload/page').then((module) => ({ default: module.default })));
+const FeedPage = lazy(() => import('@Pages/Root/feed/page').then((module) => ({ default: module.default })));
+const MyPage = lazy(() => import('@Pages/Root/mypage/page').then((module) => ({ default: module.default })));
 
 /** Auth */
 const KakaoCallback = lazy(() => import('@Pages/Auth/KakaoCallback').then((module) => ({ default: module.default })));
@@ -30,12 +34,17 @@ export const routesFromElements = createRoutesFromElements(
       <Route path="login" element={<LoginPage />} />
       <Route path="initialize-account" element={<InitializeAccountPage />} />
       <Route element={<ProtectedRoute />}>
-        <Route element={<AppLayout />}>
-          <Route path="archive" />
+        <Route
+          element={
+            <Suspense fallback={<>앱 레이아웃 로딩중 !</>}>
+              <AppLayout />
+            </Suspense>
+          }>
+          <Route path="archive" element={<ArchivePage />} />
           <Route path="vote-fap" element={<VoteFAPPage />} />
-          <Route path="upload" />
-          <Route path="feed" />
-          <Route path="mypage" />
+          <Route path="upload" element={<UploadPage />} />
+          <Route path="feed" element={<FeedPage />} />
+          <Route path="mypage" element={<MyPage />} />
         </Route>
       </Route>
     </Route>


### PR DESCRIPTION
### 관련된 이슈 번호를 기입해주세요.
> `close #이슈번호` 와 같은 형식으로 작성해주세요.

- close #30 

### 어떤 부분이 변경됐나요?
> 어떤 부분을 변경했는지, 무슨 이유로 코드를 변경했는지 설명해주세요.

- MVP에 해당하는 경로를 설정하고 경로 확인을 위한 임시 페이지를 작성했어요.
- Lazy Component에 Fallback Component를 작성했어요.
  - AppLayout에 대한 Fallback과, AppLayout 내부 Outlet에 대한 Fallback을 지정했어요.
  - 만약 페이지 마다 다른 Skeleton UI를 보여준다면 밖으로 빼야하긴..합니다
- 라우팅 과정 중에 UI 업데이트가 불안정한 구조가 발견돼서 수정했어요.
  - RootPage로 들어오면 useEffect()를 사용하는 것이 아니라 곧바로 signIn을 처리했었어요.
  - 생각해보니 signIn은 useAuthAction()에서 나온 거라, useEffect()로 감싸줘야 했어요.

### 추가 정보 (선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.

- 해당 없음
