### PR TITLE
사진 업로드 가이드 Bottom Sheet 구현

### DIFF
--- a/src/pages/Root/_dialogs/UploadDialog/components/UploadGuideBottomSheet.tsx
+++ b/src/pages/Root/_dialogs/UploadDialog/components/UploadGuideBottomSheet.tsx
@@ -1,0 +1,56 @@
+import { ReactNode, useState } from 'react';
+import * as AlertDialog from '@radix-ui/react-alert-dialog';
+import { AnimatePresence } from 'framer-motion';
+import { DialogOverlay } from '../../components/DialogOverlay';
+import { AnimatedDialog } from '../../components/AnimatedDialog';
+import { FlexibleLayout } from '@Layouts/FlexibleLayout';
+
+export function UploadGuideBottomSheet({ triggerSlot }: { triggerSlot: ReactNode }) {
+  const [isOpened, setIsOpened] = useState(false);
+
+  const handleOpenChange = (wouldOpen: boolean) => {
+    setIsOpened(wouldOpen);
+  };
+
+  return (
+    <AlertDialog.Root open={isOpened} onOpenChange={handleOpenChange}>
+      <AlertDialog.Trigger asChild>{triggerSlot}</AlertDialog.Trigger>
+
+      <AnimatePresence>
+        {isOpened && (
+          <AlertDialog.Portal forceMount container={document.getElementById('rootLayout')!}>
+            <DialogOverlay onClick={() => handleOpenChange(false)} />
+            <AlertDialog.Title />
+            <AlertDialog.Content asChild>
+              <AnimatedDialog modalType="bottomSheet">
+                <FlexibleLayout.Root>
+                  <FlexibleLayout.Header>
+                    <header className="relative px-5 py-4">
+                      <p className="text-center text-2xl font-semibold">사진 업로드 가이드</p>
+                    </header>
+                  </FlexibleLayout.Header>
+
+                  <FlexibleLayout.Content>
+                    <ul className="list-disc space-y-5">
+                      <li className="ml-5 whitespace-pre-line">{`FADE는 스타일에만 집중하고자 합니다.\n최대한 얼굴이 보이지 않는 사진으로 올려주세요!\nFADE만의 문화를 함께 만들어가요! :)`}</li>
+                      <li className="ml-5 whitespace-pre-line">{`회원님의 스타일이 잘 보이는 사진이 좋습니다.\n얼굴 제외 전신을 볼 수 있는 사진으로 올려주세요!`}</li>
+                      <li className="ml-5 whitespace-pre-line">{`FADE는 공정한 FA:P 투표를 위해 노력하고 있습니다.\n공정성을 위해 이미 올린 사진은 다시 올릴 수 없어요!`}</li>
+                    </ul>
+                  </FlexibleLayout.Content>
+
+                  <FlexibleLayout.Footer>
+                    <div className="flex p-4">
+                      <button className="flex-1 rounded-lg bg-gray-200 py-2 text-xl text-black transition-colors" onClick={() => handleOpenChange(false)}>
+                        확인
+                      </button>
+                    </div>
+                  </FlexibleLayout.Footer>
+                </FlexibleLayout.Root>
+              </AnimatedDialog>
+            </AlertDialog.Content>
+          </AlertDialog.Portal>
+        )}
+      </AnimatePresence>
+    </AlertDialog.Root>
+  );
+}

--- a/src/pages/Root/_dialogs/UploadDialog/view.tsx
+++ b/src/pages/Root/_dialogs/UploadDialog/view.tsx
@@ -12,6 +12,7 @@ import { z } from 'zod';
 import { AnimatedDialog } from '../components/AnimatedDialog';
 import { SelectStyleDialog } from '../SelectStyleDialog/dialog';
 import { InputImageFile } from './components/InputImageFile';
+import { UploadGuideBottomSheet } from './components/UploadGuideBottomSheet';
 
 /** 착장 정보 스키마 */
 const outfitItemSchema = z
@@ -129,15 +130,21 @@ export const UploadView = forwardRef(({ onClose, onValueChanged }: UploadViewPro
 function Header({ onClose }: { onClose: () => void }) {
   return (
     <header className="relative px-5 py-4">
-      <button className="absolute left-4 top-1/2 -translate-y-1/2 cursor-pointer rounded-lg p-2 hover:bg-gray-200" onClick={onClose}>
-        <MdClose className="size-6" />
+      <button className="group absolute left-4 top-1/2 -translate-y-1/2 cursor-pointer rounded-lg p-2 pointerdevice:hover:bg-gray-100" onClick={onClose}>
+        <MdClose className="size-6 group-active:pointerdevice:scale-95" />
       </button>
 
       <p className="text-center text-2xl font-semibold">사진 업로드</p>
 
-      <button className="absolute right-4 top-1/2 -translate-y-1/2 cursor-pointer rounded-lg p-2 hover:bg-gray-200">
-        <MdInfoOutline className="size-6" />
-      </button>
+      <UploadGuideBottomSheet
+        triggerSlot={
+          <button
+            type="button"
+            className="group absolute right-4 top-1/2 -translate-y-1/2 cursor-pointer rounded-lg p-2 transition-transform pointerdevice:hover:bg-gray-100">
+            <MdInfoOutline className="size-6 group-active:pointerdevice:active:scale-95" />
+          </button>
+        }
+      />
     </header>
   );
 }

--- a/src/pages/Root/_dialogs/components/AnimatedDialog.tsx
+++ b/src/pages/Root/_dialogs/components/AnimatedDialog.tsx
@@ -1,16 +1,17 @@
+import { cn } from '@Utils/index';
 import { Variants, motion } from 'framer-motion';
 import { PropsWithChildren } from 'react';
 
 const slideUpVariants: Variants = {
   hide: { y: '100%', scale: '85%', opacity: '80%', transformOrigin: 'bottom' },
   show: { y: 0, scale: '100%', opacity: '100%' },
-  exit: { y: '100%', scale: '85%', opacity: '80%', transition: { duration: 0.3 } },
+  exit: { y: '100%', scale: '85%', opacity: '80%', transition: { duration: 0.2 } },
 };
 
 const slideInFromRightVariants: Variants = {
   hide: { x: '100%', scale: '85%', opacity: '80%', transformOrigin: 'right' },
   show: { x: '0', scale: '100%', opacity: '100%' },
-  exit: { x: '100%', scale: '85%', opacity: '80%', transition: { duration: 0.3 } },
+  exit: { x: '100%', scale: '85%', opacity: '80%', transition: { duration: 0.2 } },
 };
 
 type AnimateType = 'slideUp' | 'slideInFromRight';
@@ -20,14 +21,27 @@ const variantsMap: Record<AnimateType, Variants> = {
   slideInFromRight: slideInFromRightVariants,
 };
 
-export function AnimatedDialog({ animateType = 'slideUp', children }: PropsWithChildren<{ animateType?: AnimateType }>) {
+type ModalType = 'fullScreenDialog' | 'bottomSheet';
+
+type AnimatedDialogProps = {
+  animateType?: AnimateType;
+  modalType?: ModalType;
+};
+
+export function AnimatedDialog({ animateType = 'slideUp', modalType = 'fullScreenDialog', children }: PropsWithChildren<AnimatedDialogProps>) {
+  const isFullScreenDialog = modalType === 'fullScreenDialog';
+  const isBottomSheet = modalType === 'bottomSheet';
+
   return (
     <motion.div
       initial="hide"
       animate="show"
       exit="exit"
       variants={variantsMap[animateType]}
-      className="pointer-events-auto absolute bottom-0 left-0 flex h-full w-full flex-col bg-white">
+      className={cn('pointer-events-auto absolute flex w-full flex-col bg-white', {
+        ['bottom-0 left-0 h-full']: isFullScreenDialog,
+        ['bottom-0 left-0 h-fit rounded-t-2xl']: isBottomSheet,
+      })}>
       {children}
     </motion.div>
   );

--- a/src/pages/Root/_dialogs/components/DialogOverlay.tsx
+++ b/src/pages/Root/_dialogs/components/DialogOverlay.tsx
@@ -12,6 +12,20 @@ const variants: Variants = {
   opacityIn: { opacity: 1 },
 };
 
-export const DialogOverlay = forwardRef(() => {
-  return <motion.div key="overlay" variants={variants} initial="opacityOut" animate="opacityIn" exit="opacityOut" className="fixed inset-0 overflow-auto bg-black/50" />;
+type DialogOverlayProp = {
+  onClick?: () => void;
+};
+
+export const DialogOverlay = forwardRef(({ onClick }: DialogOverlayProp) => {
+  return (
+    <motion.div
+      key="overlay"
+      variants={variants}
+      initial="opacityOut"
+      animate="opacityIn"
+      exit="opacityOut"
+      className="fixed inset-0 overflow-auto bg-black/50"
+      onClick={() => onClick && onClick()}
+    />
+  );
 });


### PR DESCRIPTION
### 관련된 이슈 번호를 기입해주세요.
> `close #이슈번호` 와 같은 형식으로 작성해주세요.

- close #34 

### 어떤 부분이 변경됐나요?
> 어떤 부분을 변경했는지, 무슨 이유로 코드를 변경했는지 설명해주세요.

- 사진 업로드 가이드 Bottom Sheet를 구현했습니다.
- Modal Background Overlay Prop에 onClick Prop을 추가하였습니다.
  - Bottom Sheet의 바깥쪽 클릭할 때 닫기 제어를 위함
- AnimatedDialog에 modalType을 지정했습니다.
  - fullScreenDialog, BottomSheet로 구분했습니다.
  - 각 구분에 따라 화면 배치가 달라지도록 했습니다. 
- 사진 업로드 Dialog에서 Info Button에 Trigger를 달았습니다.
- Exit Transition의 Duration을 미세 조정하였습니다. 

![GIF 2024-07-09 오후 3-26-41](https://github.com/swyp-fade/fade-frontend/assets/48979587/58be80bc-7ff5-47a9-8247-a2315e757a90)


### 추가 정보 (선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.

- 해당 없음
