### PR TITLE
사진 업로드 정책 화면 구현

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@radix-ui/react-select": "^2.1.1",
     "@radix-ui/react-slot": "^1.1.0",
     "@radix-ui/react-toggle-group": "^1.1.0",
+    "@radix-ui/react-visually-hidden": "^1.1.0",
     "@tanstack/react-query": "^5.49.2",
     "axios": "^1.7.2",
     "class-variance-authority": "^0.7.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       '@radix-ui/react-toggle-group':
         specifier: ^1.1.0
         version: 1.1.0(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-visually-hidden':
+        specifier: ^1.1.0
+        version: 1.1.0(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@tanstack/react-query':
         specifier: ^5.49.2
         version: 5.49.2(react@18.3.1)

--- a/src/pages/Root/_dialogs/SelectStyleDialog/dialog.tsx
+++ b/src/pages/Root/_dialogs/SelectStyleDialog/dialog.tsx
@@ -3,6 +3,7 @@ import { AnimatePresence } from 'framer-motion';
 import { ReactNode, useState } from 'react';
 import { SelectStyleView } from './view';
 import { OutfitStyle } from '@Types/outfitStyle';
+import { VisuallyHidden } from '@radix-ui/react-visually-hidden';
 
 type SelectStyleDialogProp = {
   triggerSlot: ReactNode;
@@ -21,7 +22,11 @@ export function SelectStyleDialog({ triggerSlot, defaultStyles, onStylesSelected
         {isOpened && (
           <AlertDialog.Portal forceMount container={document.getElementById('rootLayout')!}>
             <AlertDialog.Title />
-            <AlertDialog.Content asChild>
+            <AlertDialog.Content>
+              <VisuallyHidden>
+                <AlertDialog.AlertDialogDescription>This description is hidden from sighted users but accessible to screen readers.</AlertDialog.AlertDialogDescription>
+              </VisuallyHidden>
+
               <SelectStyleView
                 defaultStyles={defaultStyles}
                 onClose={(styles) => {

--- a/src/pages/Root/_dialogs/UploadDialog/components/UploadGuideBottomSheet.tsx
+++ b/src/pages/Root/_dialogs/UploadDialog/components/UploadGuideBottomSheet.tsx
@@ -4,6 +4,7 @@ import { AnimatePresence } from 'framer-motion';
 import { DialogOverlay } from '../../components/DialogOverlay';
 import { AnimatedDialog } from '../../components/AnimatedDialog';
 import { FlexibleLayout } from '@Layouts/FlexibleLayout';
+import { VisuallyHidden } from '@radix-ui/react-visually-hidden';
 
 export function UploadGuideBottomSheet({ triggerSlot }: { triggerSlot: ReactNode }) {
   const [isOpened, setIsOpened] = useState(false);
@@ -21,7 +22,11 @@ export function UploadGuideBottomSheet({ triggerSlot }: { triggerSlot: ReactNode
           <AlertDialog.Portal forceMount container={document.getElementById('rootLayout')!}>
             <DialogOverlay onClick={() => handleOpenChange(false)} />
             <AlertDialog.Title />
-            <AlertDialog.Content asChild>
+            <AlertDialog.Content>
+              <VisuallyHidden>
+                <AlertDialog.AlertDialogDescription>This description is hidden from sighted users but accessible to screen readers.</AlertDialog.AlertDialogDescription>
+              </VisuallyHidden>
+
               <AnimatedDialog modalType="bottomSheet">
                 <FlexibleLayout.Root>
                   <FlexibleLayout.Header>

--- a/src/pages/Root/_dialogs/UploadDialog/components/UploadGuideBottomSheet.tsx
+++ b/src/pages/Root/_dialogs/UploadDialog/components/UploadGuideBottomSheet.tsx
@@ -20,8 +20,12 @@ export function UploadGuideBottomSheet({ triggerSlot }: { triggerSlot: ReactNode
       <AnimatePresence>
         {isOpened && (
           <AlertDialog.Portal forceMount container={document.getElementById('rootLayout')!}>
-            <DialogOverlay onClick={() => handleOpenChange(false)} />
+            <AlertDialog.Overlay>
+              <DialogOverlay onClick={() => handleOpenChange(false)} />
+            </AlertDialog.Overlay>
+
             <AlertDialog.Title />
+
             <AlertDialog.Content>
               <VisuallyHidden>
                 <AlertDialog.AlertDialogDescription>This description is hidden from sighted users but accessible to screen readers.</AlertDialog.AlertDialogDescription>

--- a/src/pages/Root/_dialogs/UploadDialog/components/UploadImageForm.tsx
+++ b/src/pages/Root/_dialogs/UploadDialog/components/UploadImageForm.tsx
@@ -5,14 +5,13 @@ import { zodResolver } from '@hookform/resolvers/zod';
 import { FlexibleLayout } from '@Layouts/FlexibleLayout';
 import * as Select from '@radix-ui/react-select';
 import { OutfitStyle } from '@Types/outfitStyle';
-import { forwardRef, useEffect, useTransition } from 'react';
+import { useEffect, useTransition } from 'react';
 import { Control, useFieldArray, useForm } from 'react-hook-form';
 import { MdChevronRight, MdClose, MdInfoOutline } from 'react-icons/md';
 import { z } from 'zod';
-import { AnimatedDialog } from '../components/AnimatedDialog';
-import { SelectStyleDialog } from '../SelectStyleDialog/dialog';
-import { InputImageFile } from './components/InputImageFile';
-import { UploadGuideBottomSheet } from './components/UploadGuideBottomSheet';
+import { SelectStyleDialog } from '../../SelectStyleDialog/dialog';
+import { InputImageFile } from './InputImageFile';
+import { UploadGuideBottomSheet } from './UploadGuideBottomSheet';
 
 /** 착장 정보 스키마 */
 const outfitItemSchema = z
@@ -44,9 +43,9 @@ const formSchema = z.object({
 
 type UploadImageSchema = z.infer<typeof formSchema>;
 
-type UploadViewProps = { onClose: () => void; onValueChanged: (isChanged: boolean) => void };
+type UploadImageFormProp = { onClose: () => void; onValueChanged: (isChanged: boolean) => void };
 
-export const UploadView = forwardRef(({ onClose, onValueChanged }: UploadViewProps, ref) => {
+export function UploadImageForm({ onClose, onValueChanged }: UploadImageFormProp) {
   const [pending, startTransition] = useTransition();
 
   const form = useForm<UploadImageSchema>({
@@ -86,46 +85,44 @@ export const UploadView = forwardRef(({ onClose, onValueChanged }: UploadViewPro
   });
 
   return (
-    <AnimatedDialog>
-      <Form {...form}>
-        <form onSubmit={form.handleSubmit(handleSubmitAfterValidation)} className="h-full space-y-8">
-          <fieldset className="flex h-full min-w-full flex-col gap-5" disabled={pending}>
-            <FlexibleLayout.Root>
-              <FlexibleLayout.Header>
-                <Header onClose={onClose} />
-              </FlexibleLayout.Header>
+    <Form {...form}>
+      <form onSubmit={form.handleSubmit(handleSubmitAfterValidation)} className="h-full space-y-8">
+        <fieldset className="flex h-full min-w-full flex-col gap-5" disabled={pending}>
+          <FlexibleLayout.Root>
+            <FlexibleLayout.Header>
+              <Header onClose={onClose} />
+            </FlexibleLayout.Header>
 
-              <FlexibleLayout.Content className="space-y-8">
-                <AddImageField control={form.control} />
-                <SelectStylesField selectedStyles={styles as unknown as OutfitStyle[]} control={form.control} />
+            <FlexibleLayout.Content className="space-y-8">
+              <AddImageField control={form.control} />
+              <SelectStylesField selectedStyles={styles as unknown as OutfitStyle[]} control={form.control} />
 
-                <div className="space-y-3">
-                  <FormLabel className="text-lg font-semibold">착장 정보</FormLabel>
-                  <div className="space-y-2">
-                    {outfitFields.map((outfitField, index) => (
-                      <div key={outfitField.id} className="flex max-w-full flex-row gap-x-2">
-                        <CategoryField control={form.control} index={index} />
-                        <BrandNameField control={form.control} index={index} disabled={watchedOutfits[index].category === -1} />
-                        <DetailField control={form.control} index={index} disabled={watchedOutfits[index].brandName === ''} />
-                      </div>
-                    ))}
-                  </div>
-
-                  <AddOutfitDetailButton disabled={couldNotAddOutfitDetail} onClick={() => append({ ...initialOutfitDetailItem })} />
+              <div className="space-y-3">
+                <FormLabel className="text-lg font-semibold">착장 정보</FormLabel>
+                <div className="space-y-2">
+                  {outfitFields.map((outfitField, index) => (
+                    <div key={outfitField.id} className="flex max-w-full flex-row gap-x-2">
+                      <CategoryField control={form.control} index={index} />
+                      <BrandNameField control={form.control} index={index} disabled={watchedOutfits[index].category === -1} />
+                      <DetailField control={form.control} index={index} disabled={watchedOutfits[index].brandName === ''} />
+                    </div>
+                  ))}
                 </div>
-              </FlexibleLayout.Content>
 
-              <FlexibleLayout.Footer>
-                <UploadButton disabled={!isValid} />
-                {/* <UploadButton disabled={false} /> */}
-              </FlexibleLayout.Footer>
-            </FlexibleLayout.Root>
-          </fieldset>
-        </form>
-      </Form>
-    </AnimatedDialog>
+                <AddOutfitDetailButton disabled={couldNotAddOutfitDetail} onClick={() => append({ ...initialOutfitDetailItem })} />
+              </div>
+            </FlexibleLayout.Content>
+
+            <FlexibleLayout.Footer>
+              <UploadButton disabled={!isValid} />
+              {/* <UploadButton disabled={false} /> */}
+            </FlexibleLayout.Footer>
+          </FlexibleLayout.Root>
+        </fieldset>
+      </form>
+    </Form>
   );
-});
+}
 
 function Header({ onClose }: { onClose: () => void }) {
   return (

--- a/src/pages/Root/_dialogs/UploadDialog/components/UploadPolicyView.tsx
+++ b/src/pages/Root/_dialogs/UploadDialog/components/UploadPolicyView.tsx
@@ -1,0 +1,41 @@
+import { FlexibleLayout } from '@Layouts/FlexibleLayout';
+import { MdClose } from 'react-icons/md';
+
+export function PolicyView({ onDegreePolicy, onAgreePolicy }: { onDegreePolicy: () => void; onAgreePolicy: () => void }) {
+  return (
+    <FlexibleLayout.Root>
+      <FlexibleLayout.Header>
+        <header className="relative px-5 py-4">
+          <button
+            className="group absolute left-4 top-1/2 -translate-y-1/2 cursor-pointer rounded-lg p-2 pointerdevice:hover:bg-gray-100"
+            onClick={() => onDegreePolicy()}>
+            <MdClose className="size-6 group-active:pointerdevice:scale-95" />
+          </button>
+
+          <p className="text-center text-2xl font-semibold">사진 업로드 정책</p>
+        </header>
+      </FlexibleLayout.Header>
+
+      <FlexibleLayout.Content>
+        <ul className="ml-5 list-decimal space-y-5 text-lg">
+          <li>{`FADE는 본인 사진 업로드를 원칙으로 합니다.`}</li>
+          <li>{`업로드한 사진은 업로드 날짜와 무관하게 모두 FA:P(일 별로 가장 많은 표를 받은 사진) 선정의 후보가 되며, 다른 유저의 투표에 포함될 수 있습니다.`}</li>
+          <li>{`업로드한 사진이 FA:P로 선정되면 FA:P 캘린더에 노출 됩니다.`}</li>
+          <li>{`업로드한 사진은 자유롭게 삭제가 가능합니다.\n그러나 FA:P로 선정된 사진을 3회 삭제 시 별도 고지 없이 계정이 정지되며 이용이 제한 됩니다.`}</li>
+          <li>{`성적 수치심을 불러일으키는 사진, 도용이나 AI를 이용한 사진, 비하 혹은 혐오의 상징이 포함된 사진은 임의로 삭제 될 수 있습니다.`}</li>
+          <li>{`업로드한 사진이 다른 유저에 의해 5회 이상 신고되면 별도 고지 없이 삭제 됩니다.`}</li>
+        </ul>
+      </FlexibleLayout.Content>
+
+      <FlexibleLayout.Footer>
+        <div className="flex p-4">
+          <button
+            className="flex-1 rounded-lg bg-black py-2 text-xl text-white transition-colors disabled:bg-gray-200 disabled:text-gray-400 disabled:pointerdevice:cursor-not-allowed"
+            onClick={() => onAgreePolicy()}>
+            동의하고 계속하기
+          </button>
+        </div>
+      </FlexibleLayout.Footer>
+    </FlexibleLayout.Root>
+  );
+}

--- a/src/pages/Root/_dialogs/UploadDialog/dialog.tsx
+++ b/src/pages/Root/_dialogs/UploadDialog/dialog.tsx
@@ -1,12 +1,19 @@
 import * as AlertDialog from '@radix-ui/react-alert-dialog';
 import { AnimatePresence } from 'framer-motion';
 import { ReactNode, useRef, useState } from 'react';
+import { AnimatedDialog } from '../components/AnimatedDialog';
 import { DialogOverlay } from '../components/DialogOverlay';
-import { UploadView } from './view';
+import { UploadImageForm } from './components/UploadImageForm';
+import { PolicyView } from './components/UploadPolicyView';
+import { VisuallyHidden } from '@radix-ui/react-visually-hidden';
 
 export function UploadViewDialog({ triggerSlot }: { triggerSlot: ReactNode }) {
   const [isOpened, setIsOpened] = useState(false);
   const dirtyRef = useRef(false);
+
+  /** TODO: User 정보로 불러와야 함 */
+  const [hasAgreementOfPolicy, setHasAgreementOfPolicy] = useState(false);
+  const shouldShowPolicyView = !hasAgreementOfPolicy;
 
   const handleOpenChange = (wouldOpen: boolean) => {
     if (wouldOpen) {
@@ -31,8 +38,18 @@ export function UploadViewDialog({ triggerSlot }: { triggerSlot: ReactNode }) {
           <AlertDialog.Portal forceMount container={document.getElementById('rootLayout')!}>
             <DialogOverlay />
             <AlertDialog.Title />
-            <AlertDialog.Content asChild>
-              <UploadView onClose={() => handleOpenChange(false)} onValueChanged={(value) => (dirtyRef.current = value)} />
+            <AlertDialog.Content>
+              <VisuallyHidden>
+                <AlertDialog.AlertDialogDescription>This description is hidden from sighted users but accessible to screen readers.</AlertDialog.AlertDialogDescription>
+              </VisuallyHidden>
+
+              <AnimatedDialog>
+                {shouldShowPolicyView ? (
+                  <PolicyView onAgreePolicy={() => setHasAgreementOfPolicy(true)} onDegreePolicy={() => handleOpenChange(false)} />
+                ) : (
+                  <UploadImageForm onClose={() => handleOpenChange(false)} onValueChanged={(value) => (dirtyRef.current = value)} />
+                )}
+              </AnimatedDialog>
             </AlertDialog.Content>
           </AlertDialog.Portal>
         )}

--- a/src/pages/Root/_dialogs/components/AnimatedDialog.tsx
+++ b/src/pages/Root/_dialogs/components/AnimatedDialog.tsx
@@ -1,5 +1,5 @@
 import { cn } from '@Utils/index';
-import { Variants, motion } from 'framer-motion';
+import { motion, Variants } from 'framer-motion';
 import { PropsWithChildren } from 'react';
 
 const slideUpVariants: Variants = {

--- a/src/pages/Root/_dialogs/components/DialogOverlay.tsx
+++ b/src/pages/Root/_dialogs/components/DialogOverlay.tsx
@@ -16,9 +16,10 @@ type DialogOverlayProp = {
   onClick?: () => void;
 };
 
-export const DialogOverlay = forwardRef(({ onClick }: DialogOverlayProp) => {
+export const DialogOverlay = forwardRef<HTMLDivElement, DialogOverlayProp>(({ onClick }: DialogOverlayProp, ref) => {
   return (
     <motion.div
+      ref={ref}
       key="overlay"
       variants={variants}
       initial="opacityOut"


### PR DESCRIPTION
### 관련된 이슈 번호를 기입해주세요.
> `close #이슈번호` 와 같은 형식으로 작성해주세요.

- close #36 

### 어떤 부분이 변경됐나요?
> 어떤 부분을 변경했는지, 무슨 이유로 코드를 변경했는지 설명해주세요.

- 업로드 정책으로 인한 사진 업로드 화면 분기
  - 정책 동의를 안 했다면(=최초 접속이라면) 정책 동의 화면으로 분기
  - 정책 동의를 했다면 사진 업로드 폼으로 분기
  - 이에 따라 명확하게 파일로 분리함
    - 기존 view.tsx -> UploadImageForm.tsx
    - 정책 화면 -> UploadPolicyView.tsx
  - 의외로 골머리였음
  - 분기 트리거는 dialog.tsx에서 진행하는 게 정답이었음.

- Radix 접근성 관련 Warning 해결
  - 나중에 해결하려고 했는데 콘솔 로그 에러 보는 데에 방해가 돼서 해결함
  - VisuallyHidden으로 Screen Reader에게만 보이게 처리

- Radix asChild 관련 이슈 해결
  - asChild하면 자식에 forwardRef로 받아온 ref를 달아줘야 함
  - 간과함
  - 생각해보니 asChild를 쓸 필요도 없어서 asChild 제거함
  - 기존 Focus Trap, Overlay 이슈 해결(...)
    - 사진 업로드 가이드에 대한 Focus Trap은 해결 안 됐음.

![GIF 2024-07-09 오후 5-40-21](https://github.com/swyp-fade/fade-frontend/assets/48979587/412bdfe2-d7fa-4d36-8a08-ccfc60c92ffd)


### 추가 정보 (선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.

- 해당 없음
