### PR TITLE
업로드 가이드 Bottom Sheet 구조 변경

### DIFF
--- a/src/pages/Root/_dialogs/UploadDialog/components/InputImageFile.tsx
+++ b/src/pages/Root/_dialogs/UploadDialog/components/InputImageFile.tsx
@@ -1,8 +1,11 @@
 import { getBase64Image, validateLocalImageFile } from '@Utils/index';
 import { ChangeEvent, useRef, useState } from 'react';
 import { MdAddPhotoAlternate } from 'react-icons/md';
+import { UploadGuideBottomSheet } from './UploadGuideBottomSheet';
 
 export function InputImageFile(props: { value: string; onChange: (value: string) => void }) {
+  const [isGuideOpened, setIsGuideOpened] = useState(false);
+
   const [imageData, setImageData] = useState<string | null>(null); // base64 data
   const inputRef = useRef<HTMLInputElement>(null);
 
@@ -37,13 +40,25 @@ export function InputImageFile(props: { value: string; onChange: (value: string)
     inputRef.current!.click();
   };
 
+  const handleSelectImageClick = () => {
+    if (hasNoImageData) {
+      return setIsGuideOpened(true);
+    }
+
+    selectImageFile();
+  };
+
   return (
-    <div className="m group flex aspect-[2.2/1] cursor-pointer items-center justify-center overflow-hidden rounded-lg bg-gray-200" onClick={() => selectImageFile()}>
-      {hasNoImageData && (
-        <MdAddPhotoAlternate className="size-20 text-gray-500 transition-transform pointerdevice:group-hover:scale-125 pointerdevice:group-active:scale-95" />
-      )}
-      {hasImageData && <img src={imageData} className="h-full object-cover" />}
-      <input ref={inputRef} type="file" id="image" name="image" accept=".jpg, jpeg, .png, .webp" onChange={handleChange} hidden />
-    </div>
+    <>
+      <UploadGuideBottomSheet isOpened={isGuideOpened} onOpenChagne={setIsGuideOpened} onAfterClose={() => selectImageFile()} />
+
+      <div className="m group flex aspect-[2.2/1] cursor-pointer items-center justify-center overflow-hidden rounded-lg bg-gray-200" onClick={handleSelectImageClick}>
+        {hasNoImageData && (
+          <MdAddPhotoAlternate className="size-20 text-gray-500 transition-transform pointerdevice:group-hover:scale-125 pointerdevice:group-active:scale-95" />
+        )}
+        {hasImageData && <img src={imageData} className="h-full object-contain" />}
+        <input ref={inputRef} type="file" id="image" name="image" accept=".jpg, jpeg, .png, .webp" onChange={handleChange} onClick={(e) => e.stopPropagation()} hidden />
+      </div>
+    </>
   );
 }

--- a/src/pages/Root/_dialogs/UploadDialog/components/UploadGuideBottomSheet.tsx
+++ b/src/pages/Root/_dialogs/UploadDialog/components/UploadGuideBottomSheet.tsx
@@ -1,27 +1,28 @@
-import { ReactNode, useState } from 'react';
-import * as AlertDialog from '@radix-ui/react-alert-dialog';
-import { AnimatePresence } from 'framer-motion';
-import { DialogOverlay } from '../../components/DialogOverlay';
-import { AnimatedDialog } from '../../components/AnimatedDialog';
 import { FlexibleLayout } from '@Layouts/FlexibleLayout';
+import * as AlertDialog from '@radix-ui/react-alert-dialog';
 import { VisuallyHidden } from '@radix-ui/react-visually-hidden';
+import { AnimatePresence } from 'framer-motion';
+import { ReactNode } from 'react';
+import { AnimatedDialog } from '../../components/AnimatedDialog';
+import { DialogOverlay } from '../../components/DialogOverlay';
 
-export function UploadGuideBottomSheet({ triggerSlot }: { triggerSlot: ReactNode }) {
-  const [isOpened, setIsOpened] = useState(false);
+type UploadGuideBottomSheetProp = {
+  isOpened: boolean;
+  triggerSlot?: ReactNode;
+  onOpenChagne: (isOpened: boolean) => void;
+  onAfterClose?: () => void;
+};
 
-  const handleOpenChange = (wouldOpen: boolean) => {
-    setIsOpened(wouldOpen);
-  };
-
+export function UploadGuideBottomSheet({ isOpened, triggerSlot, onOpenChagne, onAfterClose }: UploadGuideBottomSheetProp) {
   return (
-    <AlertDialog.Root open={isOpened} onOpenChange={handleOpenChange}>
-      <AlertDialog.Trigger asChild>{triggerSlot}</AlertDialog.Trigger>
+    <AlertDialog.Root open={isOpened} onOpenChange={onOpenChagne}>
+      {triggerSlot && <AlertDialog.Trigger asChild>{triggerSlot}</AlertDialog.Trigger>}
 
-      <AnimatePresence>
+      <AnimatePresence onExitComplete={() => onAfterClose && onAfterClose()}>
         {isOpened && (
           <AlertDialog.Portal forceMount container={document.getElementById('portalSection')!}>
             <AlertDialog.Overlay>
-              <DialogOverlay onClick={() => handleOpenChange(false)} />
+              <DialogOverlay onClick={() => onOpenChagne(false)} />
             </AlertDialog.Overlay>
 
             <AlertDialog.Title />
@@ -49,7 +50,7 @@ export function UploadGuideBottomSheet({ triggerSlot }: { triggerSlot: ReactNode
 
                   <FlexibleLayout.Footer>
                     <div className="flex p-4">
-                      <button className="flex-1 rounded-lg bg-gray-200 py-2 text-xl text-black transition-colors" onClick={() => handleOpenChange(false)}>
+                      <button type="button" className="flex-1 rounded-lg bg-gray-200 py-2 text-xl text-black transition-colors" onClick={() => onOpenChagne(false)}>
                         확인
                       </button>
                     </div>

--- a/src/pages/Root/_dialogs/UploadDialog/components/UploadImageForm.tsx
+++ b/src/pages/Root/_dialogs/UploadDialog/components/UploadImageForm.tsx
@@ -2,17 +2,17 @@ import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from '
 import { OUTFIT_CATEGORY_LIST, OUTFIT_STYLE_MAP } from '@/constants';
 import { ToggleButton } from '@Components/ui/toogleButton';
 import { zodResolver } from '@hookform/resolvers/zod';
+import { useToastActions } from '@Hooks/toast';
 import { FlexibleLayout } from '@Layouts/FlexibleLayout';
 import * as Select from '@radix-ui/react-select';
 import { OutfitStyle } from '@Types/outfitStyle';
-import { useEffect, useTransition } from 'react';
+import { useEffect, useState, useTransition } from 'react';
 import { Control, useFieldArray, useForm } from 'react-hook-form';
 import { MdChevronRight, MdClose, MdInfoOutline } from 'react-icons/md';
 import { z } from 'zod';
 import { SelectStyleDialog } from '../../SelectStyleDialog/dialog';
 import { InputImageFile } from './InputImageFile';
 import { UploadGuideBottomSheet } from './UploadGuideBottomSheet';
-import { useToastActions } from '@Hooks/toast';
 
 /** 착장 정보 스키마 */
 const outfitItemSchema = z
@@ -128,15 +128,19 @@ export function UploadImageForm({ onClose, onValueChanged }: UploadImageFormProp
 }
 
 function Header({ onClose }: { onClose: () => void }) {
+  const [isOpened, setIsOpened] = useState(false);
+
   return (
     <header className="relative px-5 py-4">
-      <button className="group absolute left-4 top-1/2 -translate-y-1/2 cursor-pointer rounded-lg p-2 pointerdevice:hover:bg-gray-100" onClick={onClose}>
+      <button type="button" className="group absolute left-4 top-1/2 -translate-y-1/2 cursor-pointer rounded-lg p-2 pointerdevice:hover:bg-gray-100" onClick={onClose}>
         <MdClose className="size-6 group-active:pointerdevice:scale-95" />
       </button>
 
       <p className="text-center text-2xl font-semibold">사진 업로드</p>
 
       <UploadGuideBottomSheet
+        isOpened={isOpened}
+        onOpenChagne={setIsOpened}
         triggerSlot={
           <button
             type="button"


### PR DESCRIPTION
### 관련된 이슈 번호를 기입해주세요.
> `close #이슈번호` 와 같은 형식으로 작성해주세요.

- close #42 

### 어떤 부분이 변경됐나요?
> 어떤 부분을 변경했는지, 무슨 이유로 코드를 변경했는지 설명해주세요.

- 사진 업로드 가이드 Bottom Sheet의 구조를 변경했어요.
  - Uncontrolled -> Controlled
- 구조 변경에 따른 기존 로직 대응을 했어요.
- 사진 파일 최초 선택 시 사진 업로드 가이드 Bottom Sheet를 호출해요.

![GIF 2024-07-10 오후 5-10-37](https://github.com/swyp-fade/fade-frontend/assets/48979587/63444cda-3fa9-498a-8884-e0b5eba949c8)

### 추가 정보 (선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.

- 해당 없음
