### PR TITLE
착장 정보 필드 디자인 변경 대응

### DIFF
--- a/src/components/AnimatedDialog.tsx
+++ b/src/components/AnimatedDialog.tsx
@@ -58,7 +58,7 @@ export function AnimatedDialog({ animateType = 'slideUp', modalType = 'fullScree
       setBoundHeight(childHeight);
     });
 
-    childResizeObserver.observe(childRef.current);
+    childResizeObserver.observe(childRef.current, { box: 'border-box' });
 
     return () => childResizeObserver.disconnect();
   }, []);

--- a/src/pages/Root/_dialogs/UploadDialog/components/OutfitFieldSheet.tsx
+++ b/src/pages/Root/_dialogs/UploadDialog/components/OutfitFieldSheet.tsx
@@ -1,0 +1,217 @@
+import { OUTFIT_CATEGORY_LIST } from '@/constants';
+import { AnimatedDialog } from '@Components/AnimatedDialog';
+import { DialogOverlay } from '@Components/DialogOverlay';
+import { FlexibleLayout } from '@Layouts/FlexibleLayout';
+import * as AlertDialog from '@radix-ui/react-alert-dialog';
+import * as Select from '@radix-ui/react-select';
+import { VisuallyHidden } from '@radix-ui/react-visually-hidden';
+import { AnimatePresence } from 'framer-motion';
+import { ChangeEvent, ReactNode, useState } from 'react';
+import { MdChevronRight, MdClose } from 'react-icons/md';
+
+type OutfitFieldSheetProp = {
+  type: 'add' | 'edit';
+  defaultOutfitField?: OutfitField;
+  triggerSlot: ReactNode;
+  onSubmit?: (outfitField: OutfitField) => void;
+  onDelete?: () => void;
+  onEdit?: (outfitField: OutfitField) => void;
+};
+
+type OutfitField = {
+  id?: string;
+  category: number;
+  brandName: string;
+  details: string;
+};
+
+const initialOutfitField: OutfitField = { category: -1, brandName: '', details: '' };
+
+export function OutfitFieldSheet({ type, triggerSlot, defaultOutfitField = initialOutfitField, onSubmit, onDelete, onEdit }: OutfitFieldSheetProp) {
+  const [isOpened, setIsOpened] = useState(false);
+  const [outfitField, setOutfitField] = useState(defaultOutfitField);
+
+  const updateOutfitField = (field: Partial<OutfitField>) => setOutfitField((prevField) => ({ ...prevField, ...field }));
+
+  const isAddSheet = type === 'add';
+  const isEditSheet = type === 'edit';
+
+  const doneSelectCategory = outfitField.category != -1;
+  const doneInputBrandName = outfitField.brandName !== '';
+  const couldEnableAddButton = doneSelectCategory && doneInputBrandName;
+
+  const hasDirtyCategory = outfitField.category !== defaultOutfitField.category;
+  const hasDirtyBrandName = outfitField.brandName !== defaultOutfitField.brandName;
+  const hasDirtyDetails = outfitField.details !== defaultOutfitField.details;
+  const couldEnableEditButton = hasDirtyCategory || hasDirtyBrandName || hasDirtyDetails;
+
+  const closeSheet = () => {
+    setOutfitField(defaultOutfitField);
+    setIsOpened(false);
+  };
+
+  const handleAddClick = () => {
+    onSubmit && onSubmit(outfitField);
+    closeSheet();
+  };
+
+  const handleDelete = () => {
+    onDelete && onDelete();
+    closeSheet();
+  };
+
+  const handleEdit = () => {
+    onEdit && onEdit(outfitField);
+    closeSheet();
+  };
+
+  return (
+    <AlertDialog.Root open={isOpened} onOpenChange={setIsOpened}>
+      {triggerSlot && <AlertDialog.Trigger asChild>{triggerSlot}</AlertDialog.Trigger>}
+
+      <AnimatePresence>
+        {isOpened && (
+          <AlertDialog.Portal forceMount container={document.getElementById('portalSection')!}>
+            <AlertDialog.Overlay>
+              <DialogOverlay onClick={() => closeSheet()} />
+            </AlertDialog.Overlay>
+
+            <AlertDialog.Title />
+
+            <AlertDialog.Content>
+              <VisuallyHidden>
+                <AlertDialog.AlertDialogDescription>This description is hidden from sighted users but accessible to screen readers.</AlertDialog.AlertDialogDescription>
+              </VisuallyHidden>
+
+              <AnimatedDialog modalType="bottomSheet">
+                <FlexibleLayout.Root>
+                  <FlexibleLayout.Header>
+                    <header className="relative flex flex-row justify-between px-5 py-4">
+                      <p className="text-xl font-semibold">
+                        {isAddSheet && '착장 정보 추가'}
+                        {isEditSheet && '착장 정보 편집'}
+                      </p>
+                      <button>
+                        <MdClose className="size-6 text-gray-600" />
+                      </button>
+                    </header>
+                  </FlexibleLayout.Header>
+
+                  <FlexibleLayout.Content className="flex flex-col gap-3">
+                    <div className="flex flex-row gap-3">
+                      <CategorySelect categoryId={outfitField.category} onSelect={(category) => updateOutfitField({ category })} />
+                      <BrandNameField value={outfitField.brandName} disabled={outfitField.category === -1} onChange={(brandName) => updateOutfitField({ brandName })} />
+                    </div>
+
+                    <DetailField value={outfitField.details} disabled={outfitField.brandName === ''} onChange={(details) => updateOutfitField({ details })} />
+                  </FlexibleLayout.Content>
+
+                  <FlexibleLayout.Footer>
+                    <div className="flex p-4 pt-0">
+                      {isAddSheet && <AddOutfitButton disabled={!couldEnableAddButton} onAdd={handleAddClick} />}
+                      {isEditSheet && <DeleteOrEditButton onDelete={handleDelete} onEdit={handleEdit} disabled={!couldEnableEditButton} />}
+                    </div>
+                  </FlexibleLayout.Footer>
+                </FlexibleLayout.Root>
+              </AnimatedDialog>
+            </AlertDialog.Content>
+          </AlertDialog.Portal>
+        )}
+      </AnimatePresence>
+    </AlertDialog.Root>
+  );
+}
+
+function CategorySelect({ categoryId, onSelect }: { categoryId: number; onSelect: (categoryId: number) => void }) {
+  return (
+    <Select.Root defaultValue={categoryId !== -1 ? String(categoryId) : undefined} onValueChange={(value) => onSelect(Number(value))}>
+      <Select.Trigger className="flex w-[30%] max-w-[8rem] flex-row items-center justify-between rounded-md border border-gray-200 px-3 py-3 text-gray-600">
+        <Select.Value placeholder="카테고리" />
+        <Select.Icon asChild>
+          <MdChevronRight className="rotate-90" />
+        </Select.Icon>
+      </Select.Trigger>
+
+      <Select.Portal>
+        <Select.Content>
+          <Select.ScrollUpButton />
+          <Select.Viewport className="flex flex-col gap-2 rounded-md border bg-white px-2 py-2">
+            {OUTFIT_CATEGORY_LIST.map((category, index) => (
+              <Select.Item key={category} value={index.toString()} className="cursor-pointer rounded-sm px-2 py-2 transition-colors pointerdevice:hover:bg-gray-100">
+                <Select.ItemText>{category}</Select.ItemText>
+              </Select.Item>
+            ))}
+          </Select.Viewport>
+        </Select.Content>
+      </Select.Portal>
+    </Select.Root>
+  );
+}
+
+function BrandNameField({ value, disabled, onChange }: { value: string; disabled: boolean; onChange: (value: string) => void }) {
+  return (
+    <input
+      type="text"
+      className="w-full rounded-md border border-gray-200 px-3 py-3 transition-colors disabled:bg-gray-300 disabled:text-gray-500"
+      placeholder="브랜드"
+      disabled={disabled}
+      defaultValue={value}
+      onChange={(e) => onChange(e.target.value)}
+    />
+  );
+}
+
+function DetailField({ value, disabled, onChange }: { value: string; disabled: boolean; onChange: (value: string) => void }) {
+  const [textLength, setTextLength] = useState(0);
+
+  const handleChange = (e: ChangeEvent<HTMLTextAreaElement>) => {
+    setTextLength(e.target.value.length);
+    onChange(e.target.value);
+  };
+
+  return (
+    <div
+      className="relative w-full rounded-lg bg-gray-100 p-3 transition-colors focus-within:outline focus-within:outline-2 focus-within:outline-purple-700 aria-[disabled=true]:bg-gray-300"
+      aria-disabled={disabled}>
+      <textarea
+        className="relative h-[5rem] w-full resize-none bg-transparent align-text-top outline-none transition-colors disabled:bg-gray-300 disabled:text-gray-500"
+        placeholder="구매처, 상품코드 등 상세 정보를 간략히 입력해주세요."
+        onKeyDown={(e) => e.key === 'Enter' && e.preventDefault()}
+        onChange={handleChange}
+        aria-disabled={disabled}
+        disabled={disabled}
+        defaultValue={value}
+        maxLength={20}
+      />
+      <span className="absolute bottom-3 right-3 text-xs text-gray-400">{textLength} / 20</span>
+    </div>
+  );
+}
+
+function AddOutfitButton({ disabled, onAdd }: { disabled: boolean; onAdd: () => void }) {
+  return (
+    <button
+      type="button"
+      className="flex-1 rounded-lg bg-purple-700 py-2 text-xl text-white transition-colors disabled:bg-gray-300 disabled:text-gray-500"
+      onClick={onAdd}
+      disabled={disabled}>
+      추가
+    </button>
+  );
+}
+
+function DeleteOrEditButton({ disabled, onDelete, onEdit }: { disabled: boolean; onDelete: () => void; onEdit: () => void }) {
+  return (
+    <div className="flex w-full justify-end">
+      <button className="rounded-lg bg-white px-10 py-3 text-xl font-semibold text-pink-400" onClick={onDelete}>
+        삭제
+      </button>
+      <button
+        className="rounded-lg bg-purple-700 px-10 py-3 text-xl font-semibold text-white transition-colors disabled:bg-gray-300 disabled:text-gray-500"
+        onClick={onEdit}
+        disabled={disabled}>
+        수정
+      </button>
+    </div>
+  );
+}

--- a/src/pages/Root/_dialogs/UploadDialog/components/UploadImageForm.tsx
+++ b/src/pages/Root/_dialogs/UploadDialog/components/UploadImageForm.tsx
@@ -113,7 +113,6 @@ export function UploadImageForm({ onClose, onValueChanged }: UploadImageFormProp
                   }
                   onSubmit={(outfitField) => append({ ...outfitField })}
                 />
-                {/* <AddOutfitDetailButton disabled={couldNotAddOutfitDetail} onClick={() => append({ ...initialOutfitDetailItem })} /> */}
               </div>
             </FlexibleLayout.Content>
 

--- a/src/pages/Root/_dialogs/UploadDialog/components/UploadImageForm.tsx
+++ b/src/pages/Root/_dialogs/UploadDialog/components/UploadImageForm.tsx
@@ -4,7 +4,6 @@ import { ToggleButton } from '@Components/ui/toogleButton';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useToastActions } from '@Hooks/toast';
 import { FlexibleLayout } from '@Layouts/FlexibleLayout';
-import * as Select from '@radix-ui/react-select';
 import { OutfitStyle } from '@Types/outfitStyle';
 import { useEffect, useState, useTransition } from 'react';
 import { Control, useFieldArray, useForm } from 'react-hook-form';
@@ -12,6 +11,7 @@ import { MdChevronRight, MdClose, MdInfoOutline } from 'react-icons/md';
 import { z } from 'zod';
 import { SelectStyleDialog } from '../../SelectStyleDialog/dialog';
 import { InputImageFile } from './InputImageFile';
+import { OutfitFieldSheet } from './OutfitFieldSheet';
 import { UploadGuideBottomSheet } from './UploadGuideBottomSheet';
 
 /** 착장 정보 스키마 */
@@ -33,8 +33,6 @@ const outfitItemSchema = z
 
 type OutfitItemSchema = z.infer<typeof outfitItemSchema>;
 
-const initialOutfitDetailItem: OutfitItemSchema = { category: -1, brandName: '', details: '' };
-
 /** 사진 업로드 스키마 */
 const formSchema = z.object({
   image: z.string().refine((value) => value !== '', '사진을 선택해주세요.'),
@@ -55,7 +53,7 @@ export function UploadImageForm({ onClose, onValueChanged }: UploadImageFormProp
     defaultValues: {
       image: undefined,
       styles: [],
-      outfits: [{ ...initialOutfitDetailItem }],
+      outfits: [],
     },
     mode: 'onChange',
   });
@@ -76,16 +74,7 @@ export function UploadImageForm({ onClose, onValueChanged }: UploadImageFormProp
     });
   }
 
-  const { fields: outfitFields, append } = useFieldArray({ name: 'outfits', control: form.control });
-
-  const watchedOutfits = form.watch('outfits');
-
-  const couldNotAddOutfitDetail = watchedOutfits.some(({ category, brandName }) => {
-    const doseNotSelectCategory = category === -1;
-    const doseNotInputBrandName = !doseNotSelectCategory && brandName === '';
-
-    return doseNotSelectCategory || doseNotInputBrandName;
-  });
+  const { fields: outfitFields, append, remove, update } = useFieldArray({ name: 'outfits', control: form.control });
 
   return (
     <Form {...form}>
@@ -102,17 +91,29 @@ export function UploadImageForm({ onClose, onValueChanged }: UploadImageFormProp
 
               <div className="space-y-3">
                 <FormLabel className="text-lg font-semibold">착장 정보</FormLabel>
-                <div className="space-y-2">
-                  {outfitFields.map((outfitField, index) => (
-                    <div key={outfitField.id} className="flex max-w-full flex-row gap-x-2">
-                      <CategoryField control={form.control} index={index} />
-                      <BrandNameField control={form.control} index={index} disabled={watchedOutfits[index].category === -1} />
-                      <DetailField control={form.control} index={index} disabled={watchedOutfits[index].brandName === ''} />
-                    </div>
-                  ))}
-                </div>
+                {outfitFields.length !== 0 && (
+                  <div className="space-y-2">
+                    {outfitFields.map((outfitField, index) => (
+                      <OutfitItemCard
+                        key={outfitField.id}
+                        {...outfitField}
+                        onDeleteOutfit={() => remove(index)}
+                        onEditOutfit={(outfitItem) => update(index, outfitItem)}
+                      />
+                    ))}
+                  </div>
+                )}
 
-                <AddOutfitDetailButton disabled={couldNotAddOutfitDetail} onClick={() => append({ ...initialOutfitDetailItem })} />
+                <OutfitFieldSheet
+                  type="add"
+                  triggerSlot={
+                    <button type="button" className="w-full rounded-lg border border-gray-200 py-3 transition-colors disabled:bg-gray-100 disabled:text-gray-400">
+                      정보 추가
+                    </button>
+                  }
+                  onSubmit={(outfitField) => append({ ...outfitField })}
+                />
+                {/* <AddOutfitDetailButton disabled={couldNotAddOutfitDetail} onClick={() => append({ ...initialOutfitDetailItem })} /> */}
               </div>
             </FlexibleLayout.Content>
 
@@ -162,18 +163,6 @@ function UploadButton({ disabled }: { disabled: boolean }) {
         업로드
       </button>
     </div>
-  );
-}
-
-function AddOutfitDetailButton({ onClick, disabled }: { onClick: () => void; disabled: boolean }) {
-  return (
-    <button
-      type="button"
-      onClick={onClick}
-      className="w-full rounded-lg border border-gray-200 py-3 transition-colors disabled:bg-gray-100 disabled:text-gray-400"
-      disabled={disabled}>
-      정보 추가
-    </button>
   );
 }
 
@@ -243,87 +232,35 @@ function SelectStylesField({ selectedStyles, control }: { selectedStyles: Outfit
   );
 }
 
-function CategoryField({ index, control }: { index: number; control: Control<UploadImageSchema> }) {
+function OutfitItemCard({
+  onDeleteOutfit,
+  onEditOutfit,
+  ...outfitItem
+}: OutfitItemSchema & { onDeleteOutfit: () => void; onEditOutfit: (outfitItem: OutfitItemSchema) => void }) {
   return (
-    <FormField
-      control={control}
-      name={`outfits.${index}.category`}
-      render={({ field }) => (
-        <FormItem className="flex-1">
-          <FormControl>
-            <Select.Root onValueChange={(value) => field.onChange(Number(value))}>
-              <Select.Trigger className="flex w-full flex-row items-center justify-between rounded-md border border-gray-200 px-3 py-3 text-gray-600">
-                <Select.Value placeholder="카테고리" />
-                <Select.Icon asChild>
-                  <MdChevronRight className="rotate-90" />
-                </Select.Icon>
-              </Select.Trigger>
+    <OutfitFieldSheet
+      type="edit"
+      defaultOutfitField={outfitItem}
+      triggerSlot={
+        <button type="button" className="flex w-full flex-row gap-3 rounded-lg border border-purple-50 bg-white p-3">
+          <OutfitBadge categoryType={outfitItem.category} />
 
-              <Select.Portal>
-                <Select.Content>
-                  <Select.ScrollUpButton />
-                  <Select.Viewport className="flex flex-col gap-2 rounded-md border bg-white px-2 py-2">
-                    {OUTFIT_CATEGORY_LIST.map((category, index) => (
-                      <Select.Item
-                        key={category}
-                        value={index.toString()}
-                        className="cursor-pointer rounded-sm px-2 py-2 transition-colors pointerdevice:hover:bg-gray-100">
-                        <Select.ItemText>{category}</Select.ItemText>
-                      </Select.Item>
-                    ))}
-                  </Select.Viewport>
-                </Select.Content>
-              </Select.Portal>
-            </Select.Root>
-          </FormControl>
-          <FormMessage className="text-pink-400" />
-        </FormItem>
-      )}
+          <div className="flex w-full flex-col gap-1">
+            <p className="text-left">{outfitItem.brandName}</p>
+            <p className="text-left text-sm text-gray-500">{outfitItem.details}</p>
+          </div>
+        </button>
+      }
+      onDelete={onDeleteOutfit}
+      onEdit={onEditOutfit}
     />
   );
 }
 
-function BrandNameField({ disabled, index, control }: { disabled: boolean; index: number; control: Control<UploadImageSchema> }) {
+function OutfitBadge({ categoryType }: { categoryType: number }) {
   return (
-    <FormField
-      control={control}
-      name={`outfits.${index}.brandName`}
-      render={({ field }) => (
-        <FormItem className="flex-1">
-          <FormControl>
-            <input
-              type="text"
-              className="w-full rounded-md border border-gray-200 px-3 py-3 disabled:bg-gray-100 disabled:text-gray-400 aria-[invalid=true]:border-pink-500"
-              placeholder="브랜드"
-              disabled={disabled}
-              value={field.value}
-              onChange={field.onChange}
-            />
-          </FormControl>
-        </FormItem>
-      )}
-    />
-  );
-}
-
-function DetailField({ disabled, index, control }: { disabled: boolean; index: number; control: Control<UploadImageSchema> }) {
-  return (
-    <FormField
-      control={control}
-      name={`outfits.${index}.details`}
-      render={({ field }) => (
-        <FormItem className="flex-[2_1_0%]">
-          <FormControl>
-            <input
-              className="w-full rounded-md border border-gray-200 px-3 py-3 transition-colors disabled:bg-gray-100 disabled:text-gray-400"
-              placeholder="구매처, 상품코드 등 상세 정보"
-              disabled={disabled}
-              value={field.value}
-              onChange={field.onChange}
-            />
-          </FormControl>
-        </FormItem>
-      )}
-    />
+    <div className="min-w-fit rounded-[1rem] border border-purple-100 bg-purple-50 px-5 py-3">
+      <span>{OUTFIT_CATEGORY_LIST[categoryType]}</span>
+    </div>
   );
 }


### PR DESCRIPTION
### 관련된 이슈 번호를 기입해주세요.
> `close #이슈번호` 와 같은 형식으로 작성해주세요.

- close #54 

### 어떤 부분이 변경됐나요?
> 어떤 부분을 변경했는지, 무슨 이유로 코드를 변경했는지 설명해주세요.

**착장 정보 디자인 변경에 대응하기 위해 리팩토링을 진행했어요.**
  - 착장 정보 모달 생성
  - 착장 정보 카드 생성
  - 기존 Form Schema 변경

**업데이트 및 삭제 시 모달 Exit Animation이 작동하지 않는 이슈를 수정했어요.**
  - 모달의 흐름은 Trigger Slot을 활용해 모달 코드를 미리 가져오는 형태
  - 업데이트 및 삭제 이벤트를 올려주면 outfitFields가 업데이트 되면서 리렌더링 진행
    - 그렇게 되면 Portal 부분이 아닌 모달 전체가 리렌더링되므로 애니메이션이 동작하지 않음
  - 그러므로 AnimatePresence의 onExitComplete 이벤트를 활용해 애니메이션이 끝나면 이벤트를 호출하도록 변경했음
  - 모달의 Exit 애니메이션은 동작하긴 하나,, 애니메이션이 끝날 때까지 해당 값이 변경되지 않음
  - 나중에 모달 리팩토링하면서 한번 ... ㅜㅅ ㅜ

**ResizeObserver가 Bottom Sheet의 Height를 정확하게 반환하지 않는 이슈를 수정했어요.**
  - AnimatedDialog에서 type을 Bottom Sheet/Modal로 주게 되면 콘텐츠의 크기에 자동으로 맞추게 함
  - 하지만 내부에서 h-full로 크기를 잡게 되면 이를 브라우저가 계산하면서 오차가 발생
  - 때문에 Bottom Sheet/Modal을 사용하면 콘텐츠의 루트는 h-fit을 해줘야 함
  - 요것도 모달 리팩토링 진행하면서 ...

![GIF 2024-07-13 오후 4-03-52](https://github.com/user-attachments/assets/d7174e02-7c2b-4c2e-a6b3-c1c5817ac684)

### 추가 정보 (선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.

- 해당 없음
