### PR TITLE
Confirm 모달 구현

### DIFF
--- a/src/components/AnimatedDialog.tsx
+++ b/src/components/AnimatedDialog.tsx
@@ -74,7 +74,7 @@ export function AnimatedDialog({ animateType = 'slideUp', modalType = 'fullScree
       className={cn('pointer-events-auto absolute flex w-full flex-col bg-white', {
         ['bottom-0 left-0 h-full']: isFullScreenDialog,
         ['bottom-0 left-0 h-fit rounded-t-2xl']: isBottomSheet,
-        ['top-1/2 mx-5 h-fit w-fit rounded-2xl']: isModal,
+        ['top-1/2 mx-5 h-fit w-full max-w-[calc(100%-2.5rem)] rounded-2xl']: isModal,
       })}>
       {isBottomSheet && <ChildComponent ref={childRef} {...childProps} />}
       {isFullScreenDialog && children}

--- a/src/components/ConfirmProvider.tsx
+++ b/src/components/ConfirmProvider.tsx
@@ -1,0 +1,67 @@
+import { AnimatedDialog } from '@Components/AnimatedDialog';
+import { DialogOverlay } from '@Components/DialogOverlay';
+import { FlexibleLayout } from '@Layouts/FlexibleLayout';
+import * as AlertDialog from '@radix-ui/react-alert-dialog';
+import { VisuallyHidden } from '@radix-ui/react-visually-hidden';
+import { useConfirmStore } from '@Stores/confirm';
+import { AnimatePresence } from 'framer-motion';
+import { MdWarning } from 'react-icons/md';
+
+export function ConfirmProvider() {
+  const { confirmState, handleCancel, handleConfirm } = useConfirmStore();
+
+  return (
+    <AlertDialog.Root open={confirmState?.isOpen} onOpenChange={(value) => !value && handleCancel()}>
+      <AnimatePresence>
+        {confirmState?.isOpen && (
+          <AlertDialog.Portal forceMount container={document.getElementById('portalSection')!}>
+            <AlertDialog.Overlay>
+              <DialogOverlay onClick={() => handleCancel()} />
+            </AlertDialog.Overlay>
+
+            <AlertDialog.Title />
+
+            <AlertDialog.Content>
+              <VisuallyHidden>
+                <AlertDialog.AlertDialogDescription>This description is hidden from sighted users but accessible to screen readers.</AlertDialog.AlertDialogDescription>
+              </VisuallyHidden>
+
+              <AnimatedDialog modalType="modal" animateType="showAtCenter">
+                <FlexibleLayout.Root className="h-fit">
+                  <FlexibleLayout.Content className="pt-10">
+                    <div className="space-y-8">
+                      <MdWarning className="mx-auto size-24 text-purple-100" />
+
+                      <div>
+                        <p className="text-center text-2xl font-semibold">{confirmState?.title}</p>
+                        <p className="text-center text-lg">{confirmState?.description}</p>
+                      </div>
+                    </div>
+                  </FlexibleLayout.Content>
+
+                  <FlexibleLayout.Footer>
+                    <div className="flex gap-3 p-4">
+                      <button
+                        type="button"
+                        className="flex-1 rounded-lg bg-gray-200 py-2 text-xl font-semibold text-black transition-colors"
+                        onClick={() => handleCancel()}>
+                        취소
+                      </button>
+
+                      <button
+                        type="button"
+                        className="flex-1 rounded-lg bg-pink-400 py-2 text-xl font-semibold text-white transition-colors"
+                        onClick={() => handleConfirm()}>
+                        확인
+                      </button>
+                    </div>
+                  </FlexibleLayout.Footer>
+                </FlexibleLayout.Root>
+              </AnimatedDialog>
+            </AlertDialog.Content>
+          </AlertDialog.Portal>
+        )}
+      </AnimatePresence>
+    </AlertDialog.Root>
+  );
+}

--- a/src/layouts/RootLayout.tsx
+++ b/src/layouts/RootLayout.tsx
@@ -1,3 +1,4 @@
+import { ConfirmProvider } from '@Components/ConfirmProvider';
 import { ToastProvider } from '@Components/ToastProvider';
 import { Outlet } from 'react-router-dom';
 
@@ -7,6 +8,7 @@ export default function RootLayout() {
       <Outlet />
       <div id="portalSection" />
       <ToastProvider />
+      <ConfirmProvider />
     </div>
   );
 }

--- a/src/stores/confirm.ts
+++ b/src/stores/confirm.ts
@@ -1,0 +1,45 @@
+import { create } from 'zustand';
+
+export type ConfirmState = {
+  isOpen: boolean;
+  title: string;
+  description: string;
+  resolve: ((value: boolean) => void) | null;
+};
+
+type ConfirmStore = {
+  confirmState: ConfirmState | null;
+  confirm: ({ title, description }: { title: string; description: string }) => Promise<boolean>;
+  handleConfirm: () => void;
+  handleCancel: () => void;
+};
+
+export const useConfirmStore = create<ConfirmStore>((set, get) => ({
+  confirmState: null,
+
+  confirm({ title, description }) {
+    return new Promise<boolean>((resolve) => {
+      set({ confirmState: { isOpen: true, title, description, resolve } });
+    });
+  },
+
+  handleConfirm() {
+    const { confirmState } = get();
+
+    if (confirmState?.resolve) {
+      confirmState.resolve(true);
+    }
+
+    set({ confirmState: null });
+  },
+
+  handleCancel() {
+    const { confirmState } = get();
+
+    if (confirmState?.resolve) {
+      confirmState.resolve(false);
+    }
+
+    set({ confirmState: null });
+  },
+}));


### PR DESCRIPTION
### 관련된 이슈 번호를 기입해주세요.
> `close #이슈번호` 와 같은 형식으로 작성해주세요.

- close #58 

### 어떤 부분이 변경됐나요?
> 어떤 부분을 변경했는지, 무슨 이유로 코드를 변경했는지 설명해주세요.

**Confirm 모달을 구현했어요.**
- UI 컨트롤에 신경 쓰지 않고 아래와 같이 Imperative하게 쓰고 싶었어요.
```javascript
const { confirm } = useConfirm()
const result = confirm("질문")

if (result === true) {
 // To do something...
}
```
- 그렇기에 Promise-based Modal Pattern을 이용했어요.
  - 알고보니 사실 전부터 하고 싶었던 그것이었던(!)
- confirm을 호출하면 Promise를 반환하고, 모달 내부에서 버튼을 눌러야 resolve를 진행해요.
```typescript
  confirm({ title, description }) {
    return new Promise<boolean>((resolve) => {
      set({ confirmState: { isOpen: true, title, description, resolve } });
    });
  },

  handleConfirm() {
    const { confirmState } = get();

    if (confirmState?.resolve) {
      confirmState.resolve(true);
    }

    set({ confirmState: null });
  },

  handleCancel() {
    const { confirmState } = get();

    if (confirmState?.resolve) {
      confirmState.resolve(false);
    }

    set({ confirmState: null });
  },
```

![GIF 2024-07-13 오후 8-55-56](https://github.com/user-attachments/assets/3b2bf19a-ab7b-4b7a-9e5b-0228d8b986fc)


재밌다...

### 추가 정보 (선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.

- 이런 방법을 생각해내고나니, 사실 모든 모달에 적용할 수 있겠다는 생각이 들었어요.
- 모달이라는 것 자체가 화면을 가리고 그 위에 띄우는, 즉, 해당 작업이 완료되기 전까진 이전의 작업은 Pending 상태가 되는 것이죠.
- 그렇다면 전부 Promise-based로 만드는 게 더 적절할 것이라고 생각했어요.
- 그렇게 되면 아래와 같이 UI는 Imperative하게, 구조는 Declarative하게 진행되어 더 what에 집중할 수 있을 것 같아요.

```typescript
const { state, payload } = await startSelectStyles()

if (state === 'ok') {
  // payload: styles
}
```
