### PR TITLE
Radix Dialog Escape Key 감지 인터셉트

### DIFF
--- a/src/components/ModalProvider.tsx
+++ b/src/components/ModalProvider.tsx
@@ -24,10 +24,18 @@ function Modal({ Component, id, type, props, resolve, animateType }: ModalItem) 
   const removeModal = useModalStore((state) => state.removeModal);
 
   const [isOpen, setIsOpen] = useState(true);
+  const [closeHandler, setCloseHandler] = useState<(() => Promise<boolean>) | null>(null);
 
-  /** TODO: ESC 시도 가로채기 */
   /** @param params any or undefined */
-  const handleClose = (params?: unknown) => {
+  const handleClose = async (params?: unknown) => {
+    if (closeHandler) {
+      const shouldClose = await closeHandler();
+
+      if (!shouldClose) {
+        return;
+      }
+    }
+
     setIsOpen(false);
     resolve(params);
   };
@@ -50,7 +58,7 @@ function Modal({ Component, id, type, props, resolve, animateType }: ModalItem) 
               </VisuallyHidden>
 
               <AnimatedDialog modalType={type} animateType={animateType}>
-                <Component onClose={handleClose} {...(props || {})} />
+                <Component {...(props || {})} setCloseHandler={setCloseHandler} onClose={handleClose} />
               </AnimatedDialog>
             </AlertDialog.Content>
           </AlertDialog.Portal>

--- a/src/pages/Root/_dialogs/UploadDialog/components/InputImageFile.tsx
+++ b/src/pages/Root/_dialogs/UploadDialog/components/InputImageFile.tsx
@@ -55,7 +55,12 @@ export function InputImageFile(props: { value: string; onChange: (value: string)
 
   return (
     <>
-      <div className="m group flex aspect-[2.2/1] cursor-pointer items-center justify-center overflow-hidden rounded-lg bg-gray-200" onClick={handleSelectImageClick}>
+      <div
+        role="button"
+        tabIndex={0}
+        className="m group flex aspect-[2.2/1] cursor-pointer items-center justify-center overflow-hidden rounded-lg bg-gray-200"
+        onKeyUp={(e) => ['Enter', ' '].includes(e.key) && handleSelectImageClick()}
+        onClick={handleSelectImageClick}>
         {hasNoImageData && (
           <MdAddPhotoAlternate className="size-20 text-gray-500 transition-transform pointerdevice:group-hover:scale-125 pointerdevice:group-active:scale-95" />
         )}

--- a/src/pages/Root/_dialogs/UploadDialog/dialog.tsx
+++ b/src/pages/Root/_dialogs/UploadDialog/dialog.tsx
@@ -1,23 +1,34 @@
 import { DefaultModalProps } from '@Stores/modal';
-import { useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { UploadImageForm } from './components/UploadImageForm';
 import { PolicyView } from './components/UploadPolicyView';
+import { useConfirm } from '@Hooks/modal';
 
-export function UploadViewDialog({ onClose }: DefaultModalProps) {
+export function UploadViewDialog({ setCloseHandler, onClose }: DefaultModalProps) {
   const dirtyRef = useRef(false);
 
   /** TODO: User 정보로 불러와야 함 */
   const [hasAgreementOfPolicy, setHasAgreementOfPolicy] = useState(false);
   const shouldShowPolicyView = !hasAgreementOfPolicy;
 
-  const handleFormClose = () => {
-    console.log(dirtyRef.current);
+  const confirm = useConfirm();
+
+  useEffect(() => {
+    setCloseHandler(() => confirmUnsavedChanges);
+  }, [setCloseHandler]);
+
+  const confirmUnsavedChanges = async () => {
     if (dirtyRef.current) {
-      const wouldExit = confirm('변경되지 않은 머시깽이가 있어요. 그래도 나감?');
-      return wouldExit && onClose();
+      const wouldExit = await confirm({ title: '변경되지 않은 머시깽이가 있어요.', description: '그래도 나감? 리얼로?' });
+      return wouldExit || false;
     }
 
-    onClose();
+    return true;
+  };
+
+  const handleFormClose = async () => {
+    const sholudClose = await confirmUnsavedChanges();
+    sholudClose && onClose();
   };
 
   return (

--- a/src/stores/modal.ts
+++ b/src/stores/modal.ts
@@ -23,6 +23,7 @@ export type ModalType = 'fullScreenDialog' | 'bottomSheet' | 'component';
 
 /** T: 반환값 / P: Props */
 export type DefaultModalProps<T = unknown, P = Record<string, unknown>> = {
+  setCloseHandler: (handler: () => () => Promise<boolean>) => void;
   onClose: (value?: T) => void;
 } & P;
 


### PR DESCRIPTION
### 관련된 이슈 번호를 기입해주세요.
> `close #이슈번호` 와 같은 형식으로 작성해주세요.

- close #62 

### 어떤 부분이 변경됐나요?
> 어떤 부분을 변경했는지, 무슨 이유로 코드를 변경했는지 설명해주세요.

**Radix Alert Dialog의 onOpenChange에 Promise Intercept를 추가했어요.**
  - Radix Alert Dialog는 Escape Key가 눌리면 onOpenChange 이벤트를 호출합니다.
  - 해당 이벤트를 모달 컴포넌트에 넘겨주기 위해 Promise<boolean> 타입의 closeHandler 상태를 선언했어요.
  - setCloseHandler를 모달 컴포넌트에 넘겨주고, 모달 컴포넌트는 가로챘을 때 수행할 로직을 작성해요.
  - onOpenChange가 발생했을 때 closeHandler가 존재하면 await을 통해 인터셉트 로직을 수행합니다.

**주요 코드**
- Modal Provider의 onOpenChange 로직 부분

```typescript
  const [closeHandler, setCloseHandler] = useState<(() => Promise<boolean>) | null>(null);

  /** @param params any or undefined */
  const handleClose = async (params?: unknown) => {
    if (closeHandler && !(await closeHandler())) {
      return;
    }

    setIsOpen(false);
    resolve(params);
  };

  return (
    <AlertDialog.Root open={isOpen} onOpenChange={(value) => !value && handleClose()}>
      <Component {...(props || {})} setCloseHandler={setCloseHandler} onClose={handleClose} />
    </AlertDialog.Root>
  );
```

![GIF 2024-07-15 오후 9-40-13](https://github.com/user-attachments/assets/bae83979-3648-4096-ac3f-bd23f2958787)

### 추가 정보 (선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.

- 해당 없음
