### PR TITLE
모달 종료 시 Interceptor 동작 수정

### DIFF
--- a/src/components/ModalProvider.tsx
+++ b/src/components/ModalProvider.tsx
@@ -28,12 +28,8 @@ function Modal({ Component, id, type, props, resolve, animateType }: ModalItem) 
 
   /** @param params any or undefined */
   const handleClose = async (params?: unknown) => {
-    if (closeHandler) {
-      const shouldClose = await closeHandler();
-
-      if (!shouldClose) {
-        return;
-      }
+    if (closeHandler && !(await closeHandler())) {
+      return;
     }
 
     setIsOpen(false);

--- a/src/pages/Root/_dialogs/UploadDialog/dialog.tsx
+++ b/src/pages/Root/_dialogs/UploadDialog/dialog.tsx
@@ -26,15 +26,10 @@ export function UploadViewDialog({ setCloseHandler, onClose }: DefaultModalProps
     return true;
   };
 
-  const handleFormClose = async () => {
-    const sholudClose = await confirmUnsavedChanges();
-    sholudClose && onClose();
-  };
-
   return (
     <>
       {shouldShowPolicyView && <PolicyView onAgreePolicy={() => setHasAgreementOfPolicy(true)} onDegreePolicy={onClose} />}
-      {!shouldShowPolicyView && <UploadImageForm onClose={handleFormClose} onValueChanged={(value) => (dirtyRef.current = value)} />}
+      {!shouldShowPolicyView && <UploadImageForm onClose={onClose} onValueChanged={(value) => (dirtyRef.current = value)} />}
     </>
   );
 }


### PR DESCRIPTION
자체적으로 처리하는 게 아니고 onClose로 넘겨주기

### 관련된 이슈 번호를 기입해주세요.
> `close #이슈번호` 와 같은 형식으로 작성해주세요.

- close #74 

### 어떤 부분이 변경됐나요?
> 어떤 부분을 변경했는지, 무슨 이유로 코드를 변경했는지 설명해주세요.

**컴포넌트 onClose 시에 Interceptor가 두 번 작동하는 이슈를 수정했어요.**

- 모달에서 해결해보려고 했는데, 흐름을 정리하니 그냥 컴포넌트 내에서 바로 onClose를 호출하면 해결되겠더라구요. 
- 이전 흐름: 컴포넌트 onClose -> 자체 closeHandler 후 onClose -> Radix onClose에서 handleClose -> Interceptor 호출
- 수정 흐름: 컴포넌트 onClose -> Raidx onClose -> interceptor
- 깔끔!

![GIF 2024-07-17 오후 5-25-27](https://github.com/user-attachments/assets/25ce710b-7d14-4c18-a0fe-2f5f7c9de219)

### 추가 정보 (선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.

- 해당 없음
