### PR TITLE
온보딩 페이지 PWA 환경 대응

### DIFF
--- a/src/layouts/RootLayout.tsx
+++ b/src/layouts/RootLayout.tsx
@@ -1,10 +1,22 @@
 import { ModalProvider } from '@Components/ModalProvider';
 import { ToastProvider } from '@Components/ToastProvider';
-import { Outlet } from 'react-router-dom';
+import { cn } from '@Utils/index';
+import { Outlet, useLocation } from 'react-router-dom';
+
+import onboardingBackground from '@Assets/onboarding_background.jpg';
 
 export default function RootLayout() {
+  const { pathname } = useLocation();
+
+  const isLoginPage = pathname === '/login';
+
   return (
-    <div id="rootLayout" className="relative mx-auto h-1 min-h-dvh w-full overflow-hidden pt-[var(--sat)] md:max-w-[48rem] md:border-x">
+    <div
+      id="rootLayout"
+      style={{ backgroundImage: isLoginPage ? `url('${onboardingBackground}')` : '' }}
+      className={cn('relative mx-auto h-1 min-h-dvh w-full overflow-hidden pt-[var(--sat)] md:max-w-[48rem] md:border-x', {
+        ['bg-cover bg-center bg-no-repeat']: isLoginPage,
+      })}>
       <Outlet />
       <ModalProvider />
       <ToastProvider />

--- a/src/pages/Root/login/components/Carousel.tsx
+++ b/src/pages/Root/login/components/Carousel.tsx
@@ -44,8 +44,8 @@ export function Carousel() {
   };
 
   return (
-    <div>
-      <div className="relative aspect-[3/4] w-[18.75rem] rounded-lg shadow-bento">
+    <div className="flex h-full flex-col items-center justify-center gap-2">
+      <div className="relative aspect-[3/4] h-full rounded-lg shadow-bento">
         <DissolveImages currentImageId={currentImageId} />
       </div>
 
@@ -61,14 +61,14 @@ function DissolveImages({ currentImageId }: { currentImageId: number }) {
       initial={{ opacity: 0 }}
       animate={{ opacity: index === currentImageId ? 1 : 0 }}
       style={{ backgroundImage: `url('${image}')` }}
-      className={`absolute left-0 top-0 aspect-[3/4] w-full bg-contain bg-center bg-no-repeat`}
+      className={`absolute inset-0 bg-contain bg-center bg-no-repeat`}
     />
   ));
 }
 
 function NavButtons({ currentImageId, onNavClicked }: { currentImageId: number; onNavClicked: (index: number) => void }) {
   return (
-    <ul className="mt-5 flex flex-row justify-center gap-3">
+    <ul className="flex flex-row justify-center gap-3">
       {onboardingImages.map((_, index) => (
         <li key={`nav-${index}`}>
           <button

--- a/src/pages/Root/login/page.tsx
+++ b/src/pages/Root/login/page.tsx
@@ -1,22 +1,20 @@
 import { FadeLogo } from '@Components/FadeLogo';
+import { Link } from 'react-router-dom';
 import { Carousel } from './components/Carousel';
 import { KakaoLoginButton } from './components/KakaoLoginButton';
 
-import onboardingBackground from '@Assets/onboarding_background.jpg';
-import { Link } from 'react-router-dom';
-
 export default function Page() {
   return (
-    <section className="flex h-dvh flex-col items-center justify-center" style={{ backgroundImage: `url('${onboardingBackground}')`, backgroundSize: 'cover' }}>
-      <div className="flex flex-1 items-center">
+    <section className="flex h-dvh flex-col items-center justify-center">
+      <div className="flex flex-[0.5] items-center">
         <FadeLogo />
       </div>
 
-      <div className="flex flex-1 items-center">
+      <div className="flex w-full flex-[1.2] items-center justify-center">
         <Carousel />
       </div>
 
-      <div className="flex flex-1 items-center">
+      <div className="flex flex-[0.8] items-center">
         <div className="flex flex-col gap-3">
           <KakaoLoginButton />
           <Link to="/auth/callback/kakao?code=test" className="rounded-lg border bg-gray-50 p-2 text-center">


### PR DESCRIPTION
### 관련된 이슈 번호를 기입해주세요.
> `close #이슈번호` 와 같은 형식으로 작성해주세요.

- close #92 

### 어떤 부분이 변경됐나요?
> 어떤 부분을 변경했는지, 무슨 이유로 코드를 변경했는지 설명해주세요.

**온보딩 레이아웃 배치를 변경했어요.**
- 로고, 캐러셀, 로그인 버튼의 비율을 1:1:1에서 5:12:8로 변경했어요.
- 이래야 모바일 환경에서 적정선으로 보이더라구요.

| Desktop | Responsive | Mobile |
| --- | --- | --- |
| ![image](https://github.com/user-attachments/assets/dd098654-4d74-4f7c-9482-f01de47f619b) | ![image](https://github.com/user-attachments/assets/7449e9b9-4246-4682-8c09-f740331a031e) | ![image](https://github.com/user-attachments/assets/7fc3afde-c182-42d5-a981-580845f20d49)

**PWA환경에서 온보딩 배경 이미지를 대응했어요.**
- safe area에 대응하기 위해 배경 이미지를 RootLayout로 올렸습니다.

| as-is | to-be |
| --- | --- |
|  ![image](https://github.com/user-attachments/assets/66185f3c-cbe0-4850-8a92-c0aef3e19c60) | ![image](https://github.com/user-attachments/assets/06c9abf0-e917-4be6-899d-37c95b1c2fac) |


### 추가 정보 (선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.

- 해당 없음
