### PR TITLE
API 실패 응답 핸들링 로직 작성

### DIFF
--- a/index.html
+++ b/index.html
@@ -57,6 +57,7 @@
   <body>
     <script type="module" src="/src/main.tsx" defer></script>
     <div id="root"></div>
-    <script defer src="https://cdn.swygbro.com/public/widget/swyg-widget.js"></script>
+    <!-- TODO: 배포 전에 스위그 스크립트 주석 해제하기 -->
+    <!-- <script defer src="https://cdn.swygbro.com/public/widget/swyg-widget.js"></script> -->
   </body>
 </html>

--- a/src/__mock__/handlers.ts
+++ b/src/__mock__/handlers.ts
@@ -2,6 +2,7 @@ import { addDays } from 'date-fns';
 import { HttpResponse, http } from 'msw';
 import { createAccessToken, createRefreshToken } from './utils';
 import { HttpStatusCode } from 'axios';
+import { ServiceErrorResponse } from '@Types/serviceError';
 
 const BASE_URL = import.meta.env.VITE_API_BASE_URL;
 
@@ -25,7 +26,17 @@ export const handlers = [
      * : 서비스를 처음 들어온 경우
      * */
     if (refreshToken === undefined) {
-      return new HttpResponse(JSON.stringify({ errorCode: 'no_refresh_token' }), { status: HttpStatusCode.Unauthorized });
+      return new HttpResponse(
+        JSON.stringify({
+          statusCode: HttpStatusCode.Unauthorized,
+          message: '토큰이 존재하지 않습니다.',
+          result: {
+            errorCode: 'TOKEN_NOT_EXIST',
+            data: null,
+          },
+        } as ServiceErrorResponse),
+        { status: HttpStatusCode.Unauthorized }
+      );
     }
 
     /**
@@ -82,7 +93,7 @@ export const handlers = [
       }
     );
   }),
-  http.post(`${BASE_URL}/auth/check`, async () => {
+  http.post(`${BASE_URL}/auth/social-login/KAKAO/signin`, async () => {
     const isSignedUpUser = false;
 
     if (isSignedUpUser) {
@@ -101,7 +112,14 @@ export const handlers = [
     }
 
     return HttpResponse.json(
-      { errorCode: 'no_signed_up_user' },
+      {
+        statusCode: HttpStatusCode.Unauthorized,
+        message: '',
+        result: {
+          errorCode: 'NOT_MATCH_SOCIAL_MEMBER',
+          data: { accessToken: createAccessToken(userData) },
+        },
+      } as ServiceErrorResponse<'NOT_MATCH_SOCIAL_MEMBER'>,
       {
         status: HttpStatusCode.Unauthorized,
       }

--- a/src/pages/Auth/KakaoCallback.tsx
+++ b/src/pages/Auth/KakaoCallback.tsx
@@ -1,44 +1,58 @@
-import { LoaderResponseStatus } from '@Types/loaderResponse';
 import { useAuthActions } from '@Hooks/auth';
 import { requestSignInWithCode } from '@Services/authAPI';
+import { LoaderResponseStatus } from '@Types/loaderResponse';
+import { isErrorWithData } from '@Types/serviceError';
 import { createErrorLoaderResponse, createSuccessLoaderResponse, tryCatcher } from '@Utils/index';
 import { useEffect } from 'react';
-import { LoaderFunctionArgs, useLoaderData, useNavigate, useSearchParams } from 'react-router-dom';
+import { LoaderFunctionArgs, useLoaderData, useNavigate } from 'react-router-dom';
 
 export async function loader({ request }: LoaderFunctionArgs) {
   const { searchParams } = new URL(request.url);
   const authorizationCode = searchParams.get('code');
 
+  /** 비정상적인 접근 */
   if (authorizationCode === null) {
-    return createErrorLoaderResponse({ errorCode: 'custom_error_code_1' });
+    return null;
   }
 
-  const [response, errorCode] = await tryCatcher(() => requestSignInWithCode({ authorizationCode }));
+  const [response, errorResponse] = await tryCatcher(() => requestSignInWithCode({ authorizationCode }));
 
   if (response) {
     return createSuccessLoaderResponse(response.data);
   }
 
-  return createErrorLoaderResponse({ errorCode });
+  return createErrorLoaderResponse(errorResponse);
 }
 
 export default function KakaoCallback() {
-  const [searchParams] = useSearchParams();
   const navigate = useNavigate();
 
-  const { status, payload } = useLoaderData() as Awaited<ReturnType<typeof loader>>;
+  const loaderResponse = useLoaderData() as Awaited<ReturnType<typeof loader>>;
   const { signIn } = useAuthActions();
 
   useEffect(() => {
+    /** 비정상적인 접근 */
+    if (loaderResponse === null) {
+      return navigate('/', { replace: true });
+    }
+
+    const { status, payload } = loaderResponse;
     const isValidAccess = status === LoaderResponseStatus.SUCCESS;
 
+    /** 기존 회원 로그인 */
     if (isValidAccess) {
       signIn(payload);
       return navigate('/', { replace: true });
     }
 
-    return navigate(`/signup?code=${searchParams.get('code')}`, { replace: true });
-  }, [status, payload]);
+    /** 신규 회원가입 */
+    const { result } = payload;
+
+    if (isErrorWithData(result, 'NOT_MATCH_SOCIAL_MEMBER')) {
+      const { accessToken } = result.data;
+      return navigate('/signup', { state: { accessToken }, replace: true });
+    }
+  }, [loaderResponse]);
 
   return <></>;
 }

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -29,7 +29,7 @@ const SignOut = lazy(() => import('@Pages/Auth/SignOut').then((module) => ({ def
 export const routesFromElements = createRoutesFromElements(
   <Route element={<RootLayout />}>
     <Route path="/" ErrorBoundary={GlobalErrorPage}>
-      <Route index element={<RootPage />} loader={async (params) => (await import('@Pages/Root/page')).loader(params)} />
+      <Route index element={<RootPage />} loader={async () => (await import('@Pages/Root/page')).loader()} />
       <Route path="login" element={<LoginPage />} />
       <Route path="signup" element={<SignUpPage />} />
       <Route element={<ProtectedRoute />}>

--- a/src/services/authAPI.ts
+++ b/src/services/authAPI.ts
@@ -36,7 +36,7 @@ type SignInWithCodeReponse = AuthTokens;
 
 /** 인가 코드로 로그인 요청 */
 export async function requestSignInWithCode({ authorizationCode }: SignInWithCodePayload) {
-  return await axios.post<SignInWithCodeReponse>(`/auth/check`, { authorizationCode });
+  return await axios.post<SignInWithCodeReponse>(`/auth/social-login/KAKAO/signin`, { code: authorizationCode });
 }
 
 /** 로그아웃 요청 */

--- a/src/types/serviceError.ts
+++ b/src/types/serviceError.ts
@@ -1,17 +1,89 @@
+import { HttpStatusCode } from 'axios';
+
+/**
+ * 서비스 내 핸들링하는 에러는 ServiceErrorCode에 해당함.
+ * API가 실패한다면 ServiceErrorResponse 응답을 반환함.
+ *
+ * 이때, ErrorCodeDataMap에 존재하는 errorCode라면 data를 반환하고, 해당 data 타입을 특정시켜줌.
+ * 존재하지 않은 data는 null로 반환.
+ *
+ * isErrorWithData()는 이를 타입가드하는 함수.
+ */
+
 /** 스프링 서버 내부 에러 코드 */
-export type ServiceErrorCode = 'custom_error_code_1' | 'custom_error_code_2' | 'no_signed_up_user' | 'no_refresh_token' | 'unknown_error' | 'account_already_exists';
+export type TokenErrorCode = 'TOKEN_SIGNATURE_ERROR' | 'TOKEN_EXPIRED_ERROR' | 'TOKEN_NOT_EXIST';
+export type MemberErrorCode = 'MEMBER_NOT_FOUND' | 'ALREADY_EXIST_MEMBER_ID' | 'ALREADY_EXIST_MEMBER' | 'INVALID_MEMBER_ID_AND_PASSWORD';
+export type FeedErrorCode = 'NOT_FOUND_FEED' | 'FEED_UPDATE_DENIED' | 'FEED_DELETE_DENIED';
+export type VoteErrorCode = 'DUPLICATE_VOTE_ERROR';
+export type SocialLoginErrorCode = 'NOT_MATCH_SOCIAL_MEMBER';
+export type AttachmentErrorCode = 'ALREADY_EXISTS_ATTACHMENT' | 'NOT_FOUND_ATTACHMENT';
+export type CategoryErrorCode = 'NOT_FOUND_CATEGORY';
+export type StyleErrorCode = 'NOT_FOUND_STYLE';
 
-/** 스프링 서버 내부 에러 코드 메시지 */
-export const SERVICE_ERROR_MESSAGE: Record<ServiceErrorCode, string> = {
-  custom_error_code_1: '먼가 잘못됨 클남1',
-  custom_error_code_2: '먼가 잘못됨 클남2',
-  no_signed_up_user: '가입한 유저가 아닙니다.',
-  no_refresh_token: '리프래시 토큰이 업서요',
-  unknown_error: '알 수 없는 오류',
-  account_already_exists: '이미 있는 계정ID여유',
+export type ServiceErrorCode =
+  | TokenErrorCode
+  | MemberErrorCode
+  | FeedErrorCode
+  | VoteErrorCode
+  | SocialLoginErrorCode
+  | AttachmentErrorCode
+  | CategoryErrorCode
+  | StyleErrorCode;
+
+type ErrorCodeDataMap = {
+  NOT_MATCH_SOCIAL_MEMBER: { accessToken: string };
 };
 
-/** 에러 발생 시 같이 보내주는 응답 */
-export type ServiceErrorResponse = {
-  errorCode: ServiceErrorCode;
+type ErrorData<T extends ServiceErrorCode> = T extends keyof ErrorCodeDataMap ? ErrorCodeDataMap[T] : null;
+
+/** 에러 발생 시 보내주는 응답 */
+export type ServiceErrorResponse<T extends ServiceErrorCode = ServiceErrorCode> = {
+  statusCode: HttpStatusCode;
+  message: string;
+  result: {
+    errorCode: T;
+    data: ErrorData<T>;
+  };
 };
+
+/** 타입 가드 함수 */
+export function isErrorWithData<T extends keyof ErrorCodeDataMap>(
+  result: ServiceErrorResponse['result'],
+  errorCode: T
+): result is { errorCode: T; data: ErrorCodeDataMap[T] } {
+  return result.errorCode === errorCode;
+}
+
+/**
+  //TOKEN
+  TOKEN_SIGNATURE_ERROR(HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰 입니다."),
+  TOKEN_EXPIRED_ERROR(HttpStatus.UNAUTHORIZED, "토큰이 만료 되었습니다."),
+  TOKEN_NOT_EXIST(HttpStatus.UNAUTHORIZED, "토큰이 존재하지 않습니다."),
+
+  //MEMBER
+  MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "회원 정보를 찾을 수 없습니다."),
+  ALREADY_EXIST_MEMBER_ID(HttpStatus.CONFLICT, "이미 사용중인 아이디입니다."),
+  ALREADY_EXIST_MEMBER(HttpStatus.CONFLICT, "이미 존재하는 사용자입니다."),
+  INVALID_MEMBER_ID_AND_PASSWORD(HttpStatus.BAD_REQUEST, "아이디 혹은 비밀번호를 확인해주세요."),
+
+  //FEED
+  NOT_FOUND_FEED(HttpStatus.NOT_FOUND, "게시글을 찾을 수 없습니다."),
+  FEED_UPDATE_DENIED(HttpStatus.FORBIDDEN, "게시글 수정 권한이 없습니다."),
+  FEED_DELETE_DENIED(HttpStatus.FORBIDDEN, "게시글 삭제 권한이 없습니다."),
+
+  //VOTE
+  DUPLICATE_VOTE_ERROR(HttpStatus.BAD_REQUEST, "중복된 투표입니다."),
+
+  //SOCIAL LOGIN
+  NOT_MATCH_SOCIAL_MEMBER(HttpStatus.UNAUTHORIZED, ""),
+
+  //ATTACHMENT
+  ALREADY_EXISTS_ATTACHMENT(HttpStatus.CONFLICT, "이미 동일한 이미지로 업로드된 파일이 존재합니다."),
+  NOT_FOUND_ATTACHMENT(HttpStatus.NOT_FOUND, "존재하지 않는 파일입니다."),
+
+  //CATEGORY
+  NOT_FOUND_CATEGORY(HttpStatus.NOT_FOUND, "카테고리 정보를 찾을 수 없습니다."),
+
+  //STYLE
+  NOT_FOUND_STYLE(HttpStatus.NOT_FOUND, "스타일 정보를 찾을 수 없습니다.")
+ */


### PR DESCRIPTION
### 관련된 이슈 번호를 기입해주세요.
> `close #이슈번호` 와 같은 형식으로 작성해주세요.

- close #95 

### 어떤 부분이 변경됐나요?
> 어떤 부분을 변경했는지, 무슨 이유로 코드를 변경했는지 설명해주세요.

**API 실패 응답 타입을 작성했어요.**
- API에서 실패 응답 시 Custom Error Code에 해당하는 타입 `ServiceErrorCode`을 지정했어요.
```typescript
export type TokenErrorCode = 'TOKEN_SIGNATURE_ERROR' | 'TOKEN_EXPIRED_ERROR' | 'TOKEN_NOT_EXIST';
...

export type ServiceErrorCode =
  | TokenErrorCode
  | MemberErrorCode
  | FeedErrorCode
  | VoteErrorCode
  | SocialLoginErrorCode
  | AttachmentErrorCode
  | CategoryErrorCode
  | StyleErrorCode;
```

- Custom Error Code에 따라 필요한 반환값이 있는 경우 `ErrorData` 및 `ErrorCodeDataMap`로 지정해주었어요.
  - `ErrorData`는 `ErrorCodeDataMap`에 해당하는 코드일 시 해당하는 반환 타입을 가리키고, 없다면 `null`을 가리킵니다.
  - `isErrorWithData()`는 이를 위한 타입 가드 함수입니다.
  - `isErrorWithData()`의 Usage은 아래와 같습니다.
```typescript
/** 신규 회원가입 */
const { result } = payload;

if (isErrorWithData(result, 'NOT_MATCH_SOCIAL_MEMBER')) {
  const { accessToken } = result.data; // 정확하게 추론
}
```

**코드 테스트 용으로 토큰 재갱신 로직과 카카오 로그인 로직에 반영했어요.**
- 이를 위해 Mock도 새로 작성했어요.
- 또한 `tryCatcher()` 역시 에러에 맞게 로직을 대응했어요.

### 추가 정보 (선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.

조금 더 고민해봐야 할 것은,, tryCatcher에서 올린 API 이외의 오류 타입은 어떻게 지정해야 할지?