### PR TITLE
Auth API 관련 로직 구현

### DIFF
--- a/src/__mock__/handlers.ts
+++ b/src/__mock__/handlers.ts
@@ -67,13 +67,20 @@ export const handlers = [
     });
   }),
 
-  http.post(`${BASE_URL}/auth/signup`, async ({ request }) => {
+  http.post(`${BASE_URL}/auth/social-login/KAKAO/signup`, async ({ request }) => {
     const requestPayload = (await request.json()) as { accountId: string };
     const alreadyExistAccountId = requestPayload.accountId === 'asdf';
 
     if (alreadyExistAccountId) {
       return HttpResponse.json(
-        { errorCode: 'account_already_exists' },
+        {
+          statusCode: HttpStatusCode.Unauthorized,
+          message: '',
+          result: {
+            errorCode: 'ALREADY_EXIST_MEMBER_ID',
+            data: null,
+          },
+        } as ServiceErrorResponse,
         {
           status: HttpStatusCode.Unauthorized,
         }
@@ -93,6 +100,7 @@ export const handlers = [
       }
     );
   }),
+
   http.post(`${BASE_URL}/auth/social-login/KAKAO/signin`, async () => {
     const isSignedUpUser = false;
 

--- a/src/components/AsyncErrorBoundary.tsx
+++ b/src/components/AsyncErrorBoundary.tsx
@@ -1,0 +1,38 @@
+import { useToastActions } from '@Hooks/toast';
+import { isAxiosError } from 'axios';
+import { PropsWithChildren, useEffect } from 'react';
+
+/**
+ * 비동기에서 발생하는 에러를 핸들링합니다.
+ *
+ * 기본적으로 tryCatcher 또는 React Query에서 API 에러를 잡아내고,
+ * Network Error가 발생하면 서비스 내에서 제어할 수 없는 에러이므로 AsyncErrorBoundary에서 잡아서 유저에게 알립니다.
+ * 이 외 글로벌한 에러가 발생한다면 React Router Dom의 최상위 errorElement가 렌더링됩니다.
+ */
+
+export function AsyncErrorBoundary({ children }: PropsWithChildren) {
+  const { showToast } = useToastActions();
+
+  const captureReject = (e: PromiseRejectionEvent) => {
+    e.preventDefault();
+
+    if (isAxiosError(e.reason)) {
+      return showToast({
+        type: 'error',
+        title: `알 수 없는 오류(${e.reason.name})`,
+        description: `서비스 내 알 수 없는 오류가 발생했어요.\n${e.reason.message} - ${new URL(e.reason.config?.url || import.meta.env.VITE_API_BASE_URL).pathname}`,
+      });
+    }
+
+    console.log('EB >> ', e.reason);
+
+    showToast({ type: 'error', title: '알 수 없는 오류', description: '서비스 내 알 수 없는 오류가 발생했어요.' });
+  };
+
+  useEffect(() => {
+    window.addEventListener('unhandledrejection', captureReject);
+    return () => window.removeEventListener('unhandledrejection', captureReject);
+  }, []);
+
+  return children;
+}

--- a/src/components/ui/toast.tsx
+++ b/src/components/ui/toast.tsx
@@ -37,9 +37,10 @@ export const Toast = forwardRef<ElementRef<typeof RadixToast.Root>, { value: Toa
           {isSuccess && <MdCheckCircleOutline className="size-6 text-purple-700" />}
           {isError && <MdReport className="size-6" />}
 
-          <RadixToast.Title className="flex-1">{value.title}</RadixToast.Title>
-
-          {value.description && <RadixToast.Description>{value.description}</RadixToast.Description>}
+          <div className="flex-1 pl-1">
+            <RadixToast.Title className="font-semibold">{value.title}</RadixToast.Title>
+            {value.description && <RadixToast.Description className="whitespace-pre-line">{value.description}</RadixToast.Description>}
+          </div>
 
           {wouldShowAction && value.actionSlot!()}
           {wouldShowClose && (

--- a/src/layouts/RootLayout.tsx
+++ b/src/layouts/RootLayout.tsx
@@ -4,6 +4,7 @@ import { cn } from '@Utils/index';
 import { Outlet, useLocation } from 'react-router-dom';
 
 import onboardingBackground from '@Assets/onboarding_background.jpg';
+import { AsyncErrorBoundary } from '@Components/AsyncErrorBoundary';
 
 export default function RootLayout() {
   const { pathname } = useLocation();
@@ -17,7 +18,10 @@ export default function RootLayout() {
       className={cn('relative mx-auto h-1 min-h-dvh w-full overflow-hidden pt-[var(--sat)] md:max-w-[48rem] md:border-x', {
         ['bg-cover bg-center bg-no-repeat']: isLoginPage,
       })}>
-      <Outlet />
+      <AsyncErrorBoundary>
+        <Outlet />
+      </AsyncErrorBoundary>
+
       <ModalProvider />
       <ToastProvider />
     </div>

--- a/src/pages/GlobalErrorPage.tsx
+++ b/src/pages/GlobalErrorPage.tsx
@@ -1,13 +1,34 @@
-import { isRouteErrorResponse, useRouteError } from 'react-router-dom';
+import { FlexibleLayout } from '@Layouts/FlexibleLayout';
+import { isRouteErrorResponse, Link, useRouteError } from 'react-router-dom';
 
 export default function GlobalErrorPage() {
   const error = useRouteError();
 
-  return isRouteErrorResponse(error) ? (
-    <h1>
-      {error.status} {error.statusText}
-    </h1>
-  ) : (
-    <h1>{(error as Error).message || String(error)}</h1>
+  return (
+    <FlexibleLayout.Root>
+      <FlexibleLayout.Header>
+        <header className="relative px-5 py-4">
+          <p className="text-center text-2xl font-semibold">FADE</p>
+        </header>
+      </FlexibleLayout.Header>
+
+      <FlexibleLayout.Content>
+        <div className="flex h-full flex-col items-center justify-center gap-4">
+          <p className="text-lg font-medium">어라, 개발자가 놓친 오류를 발견하셨어요!</p>
+
+          {isRouteErrorResponse(error) ? (
+            <h1>
+              {error.status} {error.statusText}
+            </h1>
+          ) : (
+            <h1>{(error as Error).message || String(error)}</h1>
+          )}
+
+          <Link to="/" className="rounded-lg bg-purple-500 px-6 py-2 font-semibold text-white">
+            메인 홈으로 돌아가기
+          </Link>
+        </div>
+      </FlexibleLayout.Content>
+    </FlexibleLayout.Root>
   );
 }

--- a/src/pages/NotFoundPage.tsx
+++ b/src/pages/NotFoundPage.tsx
@@ -1,11 +1,25 @@
+import { FlexibleLayout } from '@Layouts/FlexibleLayout';
+import { Link } from 'react-router-dom';
+
 export default function NotFound() {
-  // const error = useRouteError();
-
-  // console.error(error);
-
   return (
-    <>
-      <p>오류오류</p>
-    </>
+    <FlexibleLayout.Root>
+      <FlexibleLayout.Header>
+        <header className="relative px-5 py-4">
+          <p className="text-center text-2xl font-semibold">존재하지 않는 페이지</p>
+        </header>
+      </FlexibleLayout.Header>
+
+      <FlexibleLayout.Content>
+        <div className="flex h-full flex-col items-center justify-center gap-4">
+          <p className="text-lg font-medium">어라, 존재하지 않는 페이지로 들어오셨어요!</p>
+          <p>경로를 다시 확인해주시거나 아래의 버튼을 통해 이동해주세요.</p>
+
+          <Link to="/" className="rounded-lg bg-purple-500 px-6 py-2 font-semibold text-white">
+            메인 홈으로 돌아가기
+          </Link>
+        </div>
+      </FlexibleLayout.Content>
+    </FlexibleLayout.Root>
   );
 }

--- a/src/pages/Root/signup/components/InitializeAccountView.tsx
+++ b/src/pages/Root/signup/components/InitializeAccountView.tsx
@@ -13,18 +13,18 @@ import { Control, useForm } from 'react-hook-form';
 import { useNavigate } from 'react-router-dom';
 import { z } from 'zod';
 
-export default function InitializeAccountView({ authorizationCode }: { authorizationCode: string }) {
+export default function InitializeAccountView({ accessToken }: { accessToken: string }) {
   const navigate = useNavigate();
 
   const { showToast } = useToastActions();
   const { signIn } = useAuthActions();
 
   const handleSubmit = async (values: InitializeAccountFormSchema) => {
-    const [response, errorCode] = await tryCatcher(() =>
+    const [response, errorResponse] = await tryCatcher(() =>
       requestSignUp({
         ...values,
         signUpType: SignUpType.KAKAO,
-        authorizationCode,
+        accessToken,
       })
     );
 
@@ -33,12 +33,10 @@ export default function InitializeAccountView({ authorizationCode }: { authoriza
       return navigate('/', { replace: true });
     }
 
-    if (errorCode) {
-      if (errorCode === 'account_already_exists') {
-        return showToast({ type: 'error', title: '이미 존재하는 ID입니다.' });
-      }
+    const { errorCode } = errorResponse.result;
 
-      throw new Error(errorCode);
+    if (errorCode === 'ALREADY_EXIST_MEMBER_ID') {
+      return showToast({ type: 'error', title: '이미 존재하는 ID입니다.' });
     }
   };
 
@@ -102,8 +100,9 @@ function InitializeAccountForm({ onSubmit }: { onSubmit: (values: InitializeAcco
 
           <button
             className="group w-full self-end rounded-lg bg-purple-500 py-3 text-xl font-semibold text-white transition-colors disabled:cursor-not-allowed disabled:bg-gray-200 disabled:text-gray-400"
-            disabled={!couldSubmit}>
-            <span className="inline-block transition-transform touchdevice:group-active:scale-95 pointerdevice:group-hover:scale-105 pointerdevice:group-active:scale-95">
+            disabled={!couldSubmit}
+            aria-disabled={!couldSubmit}>
+            <span className="inline-block transition-transform group-aria-[disabled=false]:touchdevice:group-active:scale-95 group-aria-[disabled=false]:pointerdevice:group-hover:scale-105 group-aria-[disabled=false]:pointerdevice:group-active:scale-95">
               FADE 시작하기
             </span>
           </button>

--- a/src/pages/Root/signup/page.tsx
+++ b/src/pages/Root/signup/page.tsx
@@ -1,18 +1,20 @@
+import { AnimatePresence, motion } from 'framer-motion';
 import { useState } from 'react';
-import { Navigate, useSearchParams } from 'react-router-dom';
+import { Navigate, useLocation } from 'react-router-dom';
 import AgreementsView from './components/AgreementsView';
 import InitializeAccountView from './components/InitializeAccountView';
-import { AnimatePresence, motion } from 'framer-motion';
+
+type SignUpLocaitonState = { accessToken: string };
 
 export default function Page() {
   const [hasAgreements, setHasAgreements] = useState(false);
+  const { state: locationState } = useLocation();
 
-  const [searchParams] = useSearchParams();
-  const authorizationCode = searchParams.get('code');
-
-  if (authorizationCode === null || authorizationCode === '') {
+  if (locationState === null) {
     return <Navigate to="/login" />;
   }
+
+  const { accessToken } = locationState as SignUpLocaitonState;
 
   return (
     <AnimatePresence mode="wait">
@@ -23,7 +25,7 @@ export default function Page() {
       )}
       {hasAgreements && (
         <motion.div key="view-2" initial={{ opacity: 0, y: '12px' }} animate={{ opacity: 1, y: 0 }} exit={{ opacity: 0, y: '12px' }} className="h-full">
-          <InitializeAccountView authorizationCode={authorizationCode} />
+          <InitializeAccountView accessToken={accessToken} />
         </motion.div>
       )}
     </AnimatePresence>

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -28,7 +28,13 @@ const SignOut = lazy(() => import('@Pages/Auth/SignOut').then((module) => ({ def
 
 export const routesFromElements = createRoutesFromElements(
   <Route element={<RootLayout />}>
-    <Route path="/" ErrorBoundary={GlobalErrorPage}>
+    <Route
+      path="/"
+      errorElement={
+        <Suspense>
+          <GlobalErrorPage />
+        </Suspense>
+      }>
       <Route index element={<RootPage />} loader={async () => (await import('@Pages/Root/page')).loader()} />
       <Route path="login" element={<LoginPage />} />
       <Route path="signup" element={<SignUpPage />} />
@@ -47,7 +53,13 @@ export const routesFromElements = createRoutesFromElements(
       </Route>
     </Route>
 
-    <Route path="/auth" ErrorBoundary={GlobalErrorPage}>
+    <Route
+      path="/auth"
+      errorElement={
+        <Suspense>
+          <GlobalErrorPage />
+        </Suspense>
+      }>
       <Route path="callback">
         <Route path="kakao">
           <Route index element={<KakaoCallback />} loader={async (params) => (await import('@Pages/Auth/KakaoCallback')).loader(params)} />
@@ -58,6 +70,6 @@ export const routesFromElements = createRoutesFromElements(
       </Route>
     </Route>
 
-    <Route path="*" Component={NotFoundPage} />
+    <Route path="*" element={<NotFoundPage />} />
   </Route>
 );

--- a/src/services/authAPI.ts
+++ b/src/services/authAPI.ts
@@ -23,12 +23,12 @@ export const enum SignUpType {
   KAKAO = 'kakao',
 }
 
-type SignUpPayload = { signUpType: SignUpType; authorizationCode: string; accountId: string; sex: string };
+type SignUpPayload = { signUpType: SignUpType; accessToken: string; accountId: string; sex: string };
 type SignUpResponse = AuthTokens;
 
 /** 회원가입 요청 */
-export async function requestSignUp({ signUpType, authorizationCode, accountId, sex }: SignUpPayload) {
-  return await axios.post<SignUpResponse>(`/auth/signup`, { signUpType, authorizationCode, accountId, sex });
+export async function requestSignUp({ signUpType, accessToken, accountId, sex }: SignUpPayload) {
+  return await axios.post<SignUpResponse>(`/auth/social-login/KAKAO/signup`, { signUpType, accessToken, accountId, sex });
 }
 
 type SignInWithCodePayload = { authorizationCode: string };

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -41,17 +41,17 @@ export const tryCatcher = async <T, _>(tryer: () => T | Promise<T>): Promise<Try
 
       /** 네트워크 오류(disconnected, timeout, cors, etc...) */
       if (error.request) {
-        console.error(error);
+        // console.error(error);
         throw error;
       }
 
       /** 설정 문제이거나 클라이언트 코드 문제임 */
-      console.error(error);
+      // console.error(error);
       throw error;
     }
 
     /** 클라이언트 코드 문제임 */
-    console.error(error);
+    // console.error(error);
     throw error;
   }
 };


### PR DESCRIPTION
### 관련된 이슈 번호를 기입해주세요.
> `close #이슈번호` 와 같은 형식으로 작성해주세요.

- close #94 

### 어떤 부분이 변경됐나요?
> 어떤 부분을 변경했는지, 무슨 이유로 코드를 변경했는지 설명해주세요.

**소셜 로그인 API Endpoint를 변경했어요.**
- 기존 `/auth/signin`, `/auth/signup`에서 `/auth/social-login/KAKAO/signin`, `/auth/social-login/KAKAO/signup`으로 변경

**비동기 오류를 처리하는 핸들러를 작성했어요.**
- React Router Dom의 ErrorBoundary나 errorElement는 비동기 오류를 처리하지 못하더라구요
- 비동기 객체를 처리하지 않으면 발생하는 unhandledrejection 이벤트를 받아서 Toast를 띄워줬어요.
- 첫 번째로 tryCatcher()나 React Query에서 비동기 에러를 처리합니다.
- 이후 발생하는 비동기 에러는 Network Error이므로 따로 관리하고 싶었어요.
  - Network Error는 서비스 단에서 처리해줄 수 있는 게 없으므로 알림에 목적이 있어요.
  - 요걸 AsyncErrorBoundary로 작성했어요.

**전역 오류 페이지 및 404 페이지를 리디자인했어요.**
- 오류 페이지 디자인이 없긴 하지만 ... 필요하긴 하지만 ... 요구하기엔 바쁘신 것 같긴 하지만 ..

### 추가 정보 (선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.

- unhandledrejection 이벤트 말고 다른 방식으로 처리를 해주고 싶긴 한데 .. 다른 방법을 나중에 찾아보는 걸로!