### PR TITLE
투표 선택지 목록 조회 API 연동

### DIFF
--- a/src/__mock__/handlers.ts
+++ b/src/__mock__/handlers.ts
@@ -1,8 +1,32 @@
+import { ServiceErrorResponse } from '@Types/serviceError';
+import { HttpStatusCode } from 'axios';
 import { addDays } from 'date-fns';
 import { HttpResponse, delay, http } from 'msw';
 import { createAccessToken, createRefreshToken } from './utils';
-import { HttpStatusCode } from 'axios';
-import { ServiceErrorResponse } from '@Types/serviceError';
+
+import testFashionImage1 from '@Assets/test_fashion_image.jpg';
+import testFashionImage10 from '@Assets/test_fashion_image_10.jpg';
+import testFashionImage2 from '@Assets/test_fashion_image_2.jpg';
+import testFashionImage3 from '@Assets/test_fashion_image_3.jpg';
+import testFashionImage4 from '@Assets/test_fashion_image_4.jpg';
+import testFashionImage5 from '@Assets/test_fashion_image_5.webp';
+import testFashionImage6 from '@Assets/test_fashion_image_6.jpg';
+import testFashionImage7 from '@Assets/test_fashion_image_7.jpg';
+import testFashionImage8 from '@Assets/test_fashion_image_8.jpg';
+import testFashionImage9 from '@Assets/test_fashion_image_9.jpg';
+
+const testFahsionImages = [
+  testFashionImage1,
+  testFashionImage2,
+  testFashionImage3,
+  testFashionImage4,
+  testFashionImage5,
+  testFashionImage6,
+  testFashionImage7,
+  testFashionImage8,
+  testFashionImage9,
+  testFashionImage10,
+];
 
 const NETWORK_DELAY = 1000;
 const BASE_URL = import.meta.env.VITE_API_BASE_URL;
@@ -166,12 +190,12 @@ export const handlers = [
   }),
 
   /** S3 Presigned URL */
-  http.put(`https://test_url.com`, async ({ request }) => {
+  http.put(`https://test_url.com`, async () => {
     await delay(NETWORK_DELAY);
     return new HttpResponse('', { status: HttpStatusCode.Ok });
   }),
 
-  http.post(`${BASE_URL}/feeds`, async ({ request }) => {
+  http.post(`${BASE_URL}/feeds`, async () => {
     await delay(NETWORK_DELAY);
     const wouldCauseError = false;
 
@@ -193,5 +217,23 @@ export const handlers = [
     }
 
     return HttpResponse.json({ feedId: 0 }, { status: HttpStatusCode.Ok });
+  }),
+
+  http.get(`${BASE_URL}/vote/candidates`, async () => {
+    await delay(NETWORK_DELAY);
+
+    const voteCandidates = testFahsionImages.map((image) => ({
+      feedId: Math.floor(Math.random() * 100),
+      userId: Math.floor(Math.random() * 100),
+      imageURL: image,
+    }));
+
+    return HttpResponse.json({ voteCandidates }, { status: HttpStatusCode.Ok });
+  }),
+
+  http.post(`${BASE_URL}/vote/candidates`, async () => {
+    await delay(NETWORK_DELAY);
+
+    return new HttpResponse('', { status: HttpStatusCode.Ok });
   }),
 ];

--- a/src/pages/Root/login/components/Carousel.tsx
+++ b/src/pages/Root/login/components/Carousel.tsx
@@ -1,4 +1,4 @@
-import { cn } from '@Utils/index';
+import { cn, prefetchImages } from '@Utils/index';
 import { motion } from 'framer-motion';
 import { useEffect, useLayoutEffect, useState } from 'react';
 
@@ -8,11 +8,8 @@ import onboardingImage3 from '@Assets/onboarding_image_3.jpg';
 
 const onboardingImages = [onboardingImage1, onboardingImage2, onboardingImage3];
 
-const loadOnboardingImagePreload = async () => {
-  onboardingImages.forEach((image) => {
-    const img = new Image();
-    img.src = image;
-  });
+const prefetchOnboardingImages = async () => {
+  prefetchImages(onboardingImages);
 };
 
 export function Carousel() {
@@ -31,7 +28,7 @@ export function Carousel() {
   };
 
   useLayoutEffect(() => {
-    loadOnboardingImagePreload();
+    prefetchOnboardingImages();
   }, []);
 
   useEffect(() => {

--- a/src/pages/Root/voteFAP/components/RandomAvatar.tsx
+++ b/src/pages/Root/voteFAP/components/RandomAvatar.tsx
@@ -1,0 +1,11 @@
+import profileDefaultImage1 from '@Assets/profile_default_1.jpg';
+import profileDefaultImage2 from '@Assets/profile_default_2.jpg';
+import profileDefaultImage3 from '@Assets/profile_default_3.jpg';
+import profileDefaultImage4 from '@Assets/profile_default_4.jpg';
+
+const defaultProfileImages = [profileDefaultImage1, profileDefaultImage2, profileDefaultImage3, profileDefaultImage4];
+
+export function RandomAvatar() {
+  const randomProfileImage = defaultProfileImages.at(Math.floor(Math.random() * 4));
+  return <div style={{ backgroundImage: `url('${randomProfileImage}')` }} className="size-8 rounded-lg" />;
+}

--- a/src/pages/Root/voteFAP/components/VoteController.tsx
+++ b/src/pages/Root/voteFAP/components/VoteController.tsx
@@ -1,34 +1,9 @@
-import { FashionCard, useVotingStore } from '@Stores/vote';
-import { generateRandomId } from '@Utils/index';
+import { useVotingStore } from '@Stores/vote';
 import { AnimatePresence, motion, Variants } from 'framer-motion';
 import { useState } from 'react';
 import { ReadyToVoteView } from './ReadyToVoteView';
 import { RestartVotingView } from './RestartVotingView';
 import { VotingView } from './VotingView';
-
-import testFashionImage1 from '@Assets/test_fashion_image.jpg';
-import testFashionImage10 from '@Assets/test_fashion_image_10.jpg';
-import testFashionImage2 from '@Assets/test_fashion_image_2.jpg';
-import testFashionImage3 from '@Assets/test_fashion_image_3.jpg';
-import testFashionImage4 from '@Assets/test_fashion_image_4.jpg';
-import testFashionImage5 from '@Assets/test_fashion_image_5.webp';
-import testFashionImage6 from '@Assets/test_fashion_image_6.jpg';
-import testFashionImage7 from '@Assets/test_fashion_image_7.jpg';
-import testFashionImage8 from '@Assets/test_fashion_image_8.jpg';
-import testFashionImage9 from '@Assets/test_fashion_image_9.jpg';
-
-const testFahsionImages = [
-  testFashionImage1,
-  testFashionImage2,
-  testFashionImage3,
-  testFashionImage4,
-  testFashionImage5,
-  testFashionImage6,
-  testFashionImage7,
-  testFashionImage8,
-  testFashionImage9,
-  testFashionImage10,
-];
 
 const viewVariants: Variants = {
   initial: { y: -12, scale: 0.95, opacity: 0, transformOrigin: 'top center' },
@@ -38,11 +13,6 @@ const viewVariants: Variants = {
 
 const baseAnimateProps = { initial: 'initial', animate: 'animate', exit: 'exit' };
 
-const testCards: FashionCard[] = testFahsionImages.map((image) => ({
-  userId: generateRandomId(),
-  imageURL: image,
-}));
-
 const enum VoteViewType {
   BEFORE_VOTING = 'before_voting',
   VOTING = 'voting',
@@ -50,11 +20,8 @@ const enum VoteViewType {
 }
 
 export function VoteController() {
-  const setViewCards = useVotingStore((state) => state.setViewCards);
   const isVotingInProgress = useVotingStore((state) => state.isVotingInProgress);
-
   const [viewId, setViewId] = useState<VoteViewType>(isVotingInProgress ? VoteViewType.VOTING : VoteViewType.BEFORE_VOTING);
-  const setIsVotingInProgress = useVotingStore((state) => state.setIsVotingInProgress);
 
   const isBeforeVoting = viewId === VoteViewType.BEFORE_VOTING;
   const isVoting = viewId === VoteViewType.VOTING;
@@ -68,36 +35,19 @@ export function VoteController() {
         <AnimatePresence mode="wait">
           {isBeforeVoting && (
             <motion.div {...baseAnimateProps} key="view-1" variants={viewVariants} className="h-full">
-              <ReadyToVoteView
-                onStartClick={() => {
-                  setViewCards(testCards);
-                  setViewId(VoteViewType.VOTING);
-                  setIsVotingInProgress(true);
-                }}
-              />
+              <ReadyToVoteView onStartClick={() => setViewId(VoteViewType.VOTING)} />
             </motion.div>
           )}
 
           {isVoting && (
             <motion.div {...baseAnimateProps} key="view-2" variants={viewVariants} className="h-full">
-              <VotingView
-                onFinishVote={() => {
-                  setViewId(VoteViewType.AFTER_VOTING);
-                  setIsVotingInProgress(false);
-                }}
-              />
+              <VotingView onSubmitDone={() => setViewId(VoteViewType.AFTER_VOTING)} />
             </motion.div>
           )}
 
           {isAfterVoting && (
             <motion.div {...baseAnimateProps} key="view-3" variants={viewVariants} className="h-full">
-              <RestartVotingView
-                onRestartVote={() => {
-                  setViewCards(testCards);
-                  setViewId(VoteViewType.VOTING);
-                  setIsVotingInProgress(true);
-                }}
-              />
+              <RestartVotingView onRestartVote={() => setViewId(VoteViewType.VOTING)} />
             </motion.div>
           )}
         </AnimatePresence>

--- a/src/pages/Root/voteFAP/page.tsx
+++ b/src/pages/Root/voteFAP/page.tsx
@@ -2,11 +2,11 @@ import { useModalActions } from '@Hooks/modal';
 import { useHeader } from '@Hooks/useHeader';
 import { FlexibleLayout } from '@Layouts/FlexibleLayout';
 import { useVotingStore } from '@Stores/vote';
+import { AnimatePresence, motion } from 'framer-motion';
 import { useState } from 'react';
 import { MdInfoOutline, MdOutlineNotificationsNone } from 'react-icons/md';
 import { VoteController } from './components/VoteController';
 import { VotePolicyBottomSheet } from './components/VotePolicyBottomSheet';
-import { AnimatePresence, motion } from 'framer-motion';
 
 export default function Page() {
   useHeader({

--- a/src/services/vote.ts
+++ b/src/services/vote.ts
@@ -1,0 +1,21 @@
+import { axios } from '@Libs/axios';
+import { VoteResultItem } from '@Stores/vote';
+
+/** TODO: 모델로 옮기기 */
+export type VoteCandidate = {
+  feedId: number;
+  userId: number;
+  imageURL: string;
+};
+
+type GetVoteCandidatesResponse = { voteCandidates: VoteCandidate[] };
+
+export async function requestGetVoteCandidates() {
+  return await axios.get<GetVoteCandidatesResponse>('/vote/candidates');
+}
+
+type SendVoteResultPayload = VoteResultItem[];
+
+export async function requestSendVoteResult(voteItems: SendVoteResultPayload) {
+  return await axios.post('/vote/candidates', { voteItems });
+}

--- a/src/stores/vote.ts
+++ b/src/stores/vote.ts
@@ -1,21 +1,36 @@
+import { generateRandomId } from '@Utils/index';
 import { create } from 'zustand';
 
-export type FashionCard = {
-  userId: string;
+export type VoteCandidateCardType = {
+  feedId: number;
+  userId: number;
   imageURL: string;
+  anonName: string;
 };
 
 export type SwipeDirection = 'left' | 'right';
 
+export type VoteType = 'FADE_IN' | 'FADE_OUT';
+
+export type VoteResultItem = {
+  feedId: number;
+  voteType: VoteType;
+};
+
 interface VotingState {
-  viewCards: FashionCard[]; // 현재 투표 선택지
+  cycleId: string; // 현재 투표 사이클 Id
+  viewCards: VoteCandidateCardType[]; // 현재 투표 선택지
+  voteResults: VoteResultItem[]; // 투표 결과를 담아놓는 곳
   hasVotedToday: boolean; // 오늘 투표를 진행했는지?
   isVotingInProgress: boolean; // 현재 투표 중인지?
   votingCountToday: number; // 오늘 투표한 횟수
   votingProgress: number; // 1부터 시작, 1: 1을 투표할 차례라는 뜻
   swipeDirection: SwipeDirection; // 애니메이션을 위한 스와이프 방향
 
-  setViewCards: (viewCards: FashionCard[]) => void;
+  generateNewCycleId: () => void;
+  setViewCards: (viewCards: VoteCandidateCardType[]) => void;
+  updateVoteResult: (voteResult: VoteResultItem) => void;
+  clearVoteResults: () => void;
   setHasVotedToday: (hasVoted: boolean) => void;
   setIsVotingInProgress: (isInProgress: boolean) => void;
   addVotingCountToday: () => void;
@@ -27,14 +42,19 @@ interface VotingState {
 }
 
 export const useVotingStore = create<VotingState>((set, get) => ({
+  cycleId: generateRandomId(),
   viewCards: [],
+  voteResults: [],
   hasVotedToday: false,
   isVotingInProgress: false,
   votingCountToday: 0,
   votingProgress: 1,
   swipeDirection: 'right',
 
+  generateNewCycleId: () => set({ cycleId: generateRandomId() }),
   setViewCards: (viewCards) => set({ viewCards }),
+  updateVoteResult: (voteResult) => set(({ voteResults }) => ({ voteResults: [...voteResults, voteResult] })),
+  clearVoteResults: () => set({ voteResults: [] }),
   setHasVotedToday: (hasVotedToday) => set({ hasVotedToday }),
   setIsVotingInProgress: (isVotingInProgress) => set({ isVotingInProgress }),
   addVotingCountToday: () => set(({ votingCountToday }) => ({ votingCountToday: votingCountToday + 1 })),
@@ -43,7 +63,12 @@ export const useVotingStore = create<VotingState>((set, get) => ({
   setSwipeDirection: (swipeDirection) => set({ swipeDirection }),
 
   handleSelect: (swipeDirection) => {
-    const { viewCards, setViewCards, setSwipeDirection, addVotingCountToday, addVotingProgress } = get();
+    const { viewCards, setViewCards, setSwipeDirection, addVotingCountToday, addVotingProgress, updateVoteResult } = get();
+    const currentViewCard = viewCards.at(-1);
+
+    if (currentViewCard) {
+      updateVoteResult({ feedId: currentViewCard.feedId, voteType: swipeDirection === 'left' ? 'FADE_OUT' : 'FADE_IN' });
+    }
 
     setViewCards(viewCards.slice(0, -1));
     setSwipeDirection(swipeDirection);

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -2,8 +2,8 @@ import { LoaderResponse, LoaderResponseStatus } from '@Types/loaderResponse';
 import { ServiceErrorResponse } from '@Types/serviceError';
 import { isAxiosError } from 'axios';
 import { type ClassValue, clsx } from 'clsx';
-import { twMerge } from 'tailwind-merge';
 import { sha256 } from 'js-sha256';
+import { twMerge } from 'tailwind-merge';
 
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
@@ -29,7 +29,7 @@ export function createErrorLoaderResponse<T = never>(payload: ServiceErrorRespon
 
 export type TryCatcherResult<T> = [T, null] | [null, ServiceErrorResponse];
 
-export const tryCatcher = async <T, _>(tryer: () => T | Promise<T>): Promise<TryCatcherResult<T>> => {
+export const tryCatcher = async <T>(tryer: () => T | Promise<T>): Promise<TryCatcherResult<T>> => {
   try {
     const result = await tryer();
     return [result, null];
@@ -145,4 +145,19 @@ export async function calculateFileHash(file: File) {
   const hashHex = hashArray.map((b) => b.toString(16).padStart(2, '0')).join('');
 
   return hashHex;
+}
+
+export async function prefetchImages(images: string[]): Promise<void> {
+  await Promise.all(
+    images.map(
+      (image) =>
+        new Promise((resolve, reject) => {
+          const prefetchImage = new Image();
+
+          prefetchImage.addEventListener('load', () => resolve(null));
+          prefetchImage.addEventListener('error', () => reject(null));
+          prefetchImage.src = image;
+        })
+    )
+  );
 }


### PR DESCRIPTION
### 관련된 이슈 번호를 기입해주세요.
> `close #이슈번호` 와 같은 형식으로 작성해주세요.

- close #100 

### 어떤 부분이 변경됐나요?
> 어떤 부분을 변경했는지, 무슨 이유로 코드를 변경했는지 설명해주세요.

**투표 목록 조회 로딩 및 투표 결과 전송 로딩을 구현했어요.**
- 투표 목록 API를 호출하고 응답을 받는 시간
- 투표 이미지를 미리 Prefetch를 하는 시간
- 선택한 투표 결과를 전송하는 시간
- 투표 목록 조회 로딩은 Fake Progress bar를 노출해 UX적으로 액티브 웨이팅을 느끼게 했어요.
- 투표 결과 전송 로딩은 중요한 전송임을 인지하도록 artifical delay를 넣..을려고 예정이에요.
- 아이콘은 일단 .. ^___^

| 투표 목록 조회 로딩 | 투표 결과 전송 로딩 |
| --- | --- |
| ![GIF 2024-07-24 오후 12-21-48](https://github.com/user-attachments/assets/a60ee227-4365-40d5-bb0f-ced8beab9d8b) | ![GIF 2024-07-24 오후 12-22-29](https://github.com/user-attachments/assets/f8375d90-8967-4c0e-8400-08f4eeec9395) |

**투표 관련 API를 연동했어요.**
- 투표 목록 조회 API
  - 선언적으로 useQuery를 이용해 데이터를 가져오다보니, 다른 탭에 갔다가 돌아와도 패칭을 진행하는 이슈가 있었어요.
  - cycleId를 만들어 해당 사이클에 대한 캐싱을 하도록 만들었어요.
  - enabled를 isVotingInProgress로 제어했어요.
  - 이런 흐름을 가져가도 될런지 아직 고민되지만 ... 일단 작동은 하니까!
- 투표 결과 전송 API
  - 투표 결과를 담는 voteResults를 Vote Store에 추가했어요.
- 다만 아직 의논된 API 흐름으로 API가 개발이 안 돼서 모킹으로 진행했어요.

| 투표 관련 API 연동 |
| --- |
| ![GIF 2024-07-24 오후 12-29-47](https://github.com/user-attachments/assets/dce62bea-5f86-482c-953b-91fbf571e867) |

**투표 화면에 대해 내부적으로 구조 리팩토링을 진행했어요.**
- 로딩 화면이 추가적으로 필요해서 투표 화면에서도 로딩/투표/전송 화면으로 구분했어요.
- 화면 구분에 따라 Vote Store에 필요한 전역변수를 추가했어요.
- IsVotingInProgress 변수를 실제 투표 화면에 들어갔을 때 true로 바뀌도록 변경했어요.

### 추가 정보 (선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.

- 해당 없음
