### PR TITLE
아카이브 탭 레이아웃 구현

### DIFF
--- a/src/layouts/FlexibleLayout.tsx
+++ b/src/layouts/FlexibleLayout.tsx
@@ -17,7 +17,7 @@ function Header({ children }: PropsWithChildren) {
 
 function Content({ children, className, ...props }: PropsWithChildren<HTMLAttributes<HTMLDivElement>>) {
   return (
-    <section className={cn('min-h-1 flex-1 overflow-y-scroll border border-blue-300 p-5', className)} {...props}>
+    <section className={cn('min-h-1 flex-1 overflow-y-scroll border border-blue-300', className)} {...props}>
       {children}
     </section>
   );

--- a/src/pages/Root/archive/dateStyle.css
+++ b/src/pages/Root/archive/dateStyle.css
@@ -1,0 +1,29 @@
+#date_picker {
+  input[type='month']::-webkit-calendar-picker-indicator {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: transparent;
+    color: transparent;
+    cursor: pointer;
+  }
+
+  /*
+    선택할 후보가 없으면 disalbed 되는데,, 색이 grey로 변한다.
+    크롬의 user-agent stylesheet에선 [disabled]로 처리하던데 안 먹힌다.
+    그래서 걍 적용했더니 됐다.
+    
+    그런데 이러면 자동으로 지정하는 field selection에도 색깔 반전이 안 된다.
+    selection 색깔은 안 바뀌더라... 아몰랑
+  */
+
+  /* input[type='month']::-webkit-datetime-edit-year-field {
+    @apply text-gray-900;
+  }
+
+  input[type='month']::-webkit-datetime-edit-month-field {
+    @apply text-gray-900;
+  } */
+}

--- a/src/pages/Root/archive/page.tsx
+++ b/src/pages/Root/archive/page.tsx
@@ -1,7 +1,218 @@
+import testImage from '@Assets/test_fashion_image.jpg';
 import { useHeader } from '@Hooks/useHeader';
+import { cn, isBetweenDate } from '@Utils/index';
+import { addMonths, format, getDaysInMonth, getWeeksInMonth, isSameMonth, isSameYear, startOfDay, subMonths } from 'date-fns';
+import { AnimatePresence, motion, Variants } from 'framer-motion';
+import { useRef, useState, useTransition } from 'react';
+import { MdChevronLeft, MdChevronRight, MdOutlineNotificationsNone, MdSearch } from 'react-icons/md';
+import './dateStyle.css';
+
+const MIN_DATE = new Date('2024-01-01');
+const MAX_DATE = new Date();
+
+/** 여기 레이아웃이 전체적으로 이상하네... */
+
+const transitionVariants: Variants = {
+  initial: (direction: number) => ({ x: `${-10 * direction}%`, opacity: 0 }),
+  animate: { x: 0, opacity: 1 },
+  exit: (direction: number) => ({ x: `${10 * direction}%`, opacity: 0 }),
+};
+
+const baseAnimationProps = { initial: 'initial', animate: 'animate', exit: 'exit' };
 
 export default function Page() {
-  useHeader({ title: 'FA:P 아카이브' });
+  useHeader({
+    title: 'FA:P 아카이브',
+    leftSlot: () => <SearchButton />,
+    rightSlot: () => <ShowNotificationButton />,
+  });
 
-  return <>아카이브 화면</>;
+  const startTransition = useTransition()[1];
+
+  const [isTransitionInProgress, setIsTransitionInProgress] = useState(false);
+  const [direction, setDirection] = useState(1);
+  const [currentTabId, setCurrentTabId] = useState(0);
+
+  const isFAPTab = currentTabId === 0;
+  const isAllTab = currentTabId === 1;
+
+  const switchToTab = (newTabId: number) => {
+    const isSwitchToFAP = currentTabId - newTabId > 0;
+    const newDirection = isSwitchToFAP ? 1 : -1;
+
+    setIsTransitionInProgress(true);
+
+    startTransition(() => {
+      setDirection(newDirection);
+      setCurrentTabId(newTabId);
+    });
+  };
+
+  return (
+    <div className="flex h-full flex-col">
+      <menu className="sticky top-0 z-10 flex flex-row bg-white px-5">
+        <li className="flex-1">
+          <button className="relative h-full w-full py-3" onClick={() => switchToTab(0)} disabled={isTransitionInProgress}>
+            <span className={cn('text-h6 font-semibold text-gray-500 transition-colors', { ['text-current']: isFAPTab })}>FA:P 아카이브</span>
+            {isFAPTab && <TabIndicator />}
+          </button>
+        </li>
+        <li className="flex-1">
+          <button className="relative h-full w-full py-3" onClick={() => switchToTab(1)} disabled={isTransitionInProgress}>
+            <span className={cn('text-h6 font-semibold text-gray-500 transition-colors', { ['text-current']: isAllTab })}>패션 전체보기</span>
+            {isAllTab && <TabIndicator />}
+          </button>
+        </li>
+      </menu>
+
+      <div className="relative flex h-full">
+        <AnimatePresence custom={direction} initial={false} onExitComplete={() => setIsTransitionInProgress(false)}>
+          {isFAPTab && (
+            <motion.div key="fap-view" className="absolute flex h-full w-full" custom={direction} variants={transitionVariants} {...baseAnimationProps}>
+              <FAPArchivingView />
+            </motion.div>
+          )}
+          {isAllTab && (
+            <motion.div key="all-view" className="absolute flex h-full w-full" custom={direction} variants={transitionVariants} {...baseAnimationProps}>
+              <AllArchivingView />
+            </motion.div>
+          )}
+        </AnimatePresence>
+      </div>
+    </div>
+  );
+}
+
+function SearchButton() {
+  return (
+    <button className="group cursor-pointer rounded-lg p-2 touchdevice:active:bg-gray-100 pointerdevice:hover:bg-gray-100">
+      <MdSearch className="size-6 transition-transform touchdevice:group-active:scale-95 pointerdevice:group-active:scale-95" />
+    </button>
+  );
+}
+
+function ShowNotificationButton() {
+  return (
+    <button className="group cursor-pointer rounded-lg p-2 touchdevice:active:bg-gray-100 pointerdevice:hover:bg-gray-100">
+      <MdOutlineNotificationsNone className="size-6 transition-transform touchdevice:group-active:scale-95 pointerdevice:group-active:scale-95" />
+    </button>
+  );
+}
+
+function TabIndicator() {
+  return <motion.div layoutId="tab-indicator" className="absolute bottom-0 left-0 h-1 w-full bg-purple-500" />;
+}
+
+function FAPArchivingView() {
+  const inputDateRef = useRef<HTMLInputElement>(null);
+  const [calenderDate, setCalenderDate] = useState(format(new Date(), 'yyyy-MM'));
+
+  const isMinDate = isSameYear(calenderDate, MIN_DATE) && isSameMonth(calenderDate, MIN_DATE);
+  const isMaxDate = isSameYear(calenderDate, MAX_DATE) && isSameMonth(calenderDate, MAX_DATE);
+
+  const updateDate = (newDate: Date | null) => {
+    /** Webkit에서 삭제 버튼 눌렀을 때 */
+    if (newDate === null) {
+      return setCalenderDate(format(new Date(), 'yyyy-MM'));
+    }
+
+    /** 유효성 검사 */
+    if (!isBetweenDate(MIN_DATE, newDate, MAX_DATE)) {
+      return setCalenderDate(format(new Date(), 'yyyy-MM'));
+    }
+
+    setCalenderDate(format(newDate, 'yyyy-MM'));
+  };
+
+  const weeksInMonth = getWeeksInMonth(calenderDate);
+  const firstDayOfWeek = format(startOfDay(calenderDate), 'e');
+  // const columnStart = `[&>div:nth-child(1)]:col-start-${firstDayOfWeek}`;
+
+  return (
+    <div className="flex flex-1 flex-col p-5">
+      <div className="relative flex justify-center rounded-lg border border-gray-200 py-2">
+        {/* TODO: disabled css 처리 */}
+        <button
+          className="group absolute left-3 top-1/2 -translate-y-1/2 cursor-pointer rounded-lg p-2 touchdevice:active:bg-gray-100 pointerdevice:hover:bg-gray-100"
+          onClick={() => updateDate(subMonths(calenderDate, 1))}
+          disabled={isMinDate}>
+          <MdChevronLeft className="size-6 transition-transform touchdevice:group-active:scale-95 pointerdevice:group-active:scale-95" />
+        </button>
+
+        {/* 나중에 Date Picker 진짜 바꿔야겠다 ... 개열받네 */}
+        <div id="date_picker">
+          <input
+            ref={inputDateRef}
+            type="month"
+            className="relative whitespace-nowrap rounded-lg bg-gray-100 px-4 py-[.375rem] text-h6"
+            value={calenderDate}
+            defaultValue={format(new Date(), 'yyyy-MM')}
+            onInput={(e) => updateDate(e.currentTarget.valueAsDate)}
+            min={format(MIN_DATE, 'yyyy-MM')}
+            max={format(MAX_DATE, 'yyyy-MM')}
+          />
+        </div>
+
+        <button
+          className="group absolute right-3 top-1/2 -translate-y-1/2 cursor-pointer rounded-lg p-2 touchdevice:active:bg-gray-100 pointerdevice:hover:bg-gray-100"
+          onClick={() => updateDate(addMonths(calenderDate, 1))}
+          disabled={isMaxDate}>
+          <MdChevronRight className="size-6 transition-transform touchdevice:group-active:scale-95 pointerdevice:group-active:scale-95" />
+        </button>
+      </div>
+
+      <div>
+        <ul className="flex flex-row py-5">
+          {['일', '월', '화', '수', '목', '금', '토'].map((dayOfWeek, index) => (
+            <li
+              className={cn('flex-1 text-center', {
+                ['text-pink-400']: index === 0,
+                ['text-purple-900']: index === 6,
+              })}>
+              {dayOfWeek}
+            </li>
+          ))}
+        </ul>
+      </div>
+
+      <div style={{ gridRow: weeksInMonth }} className={`grid flex-1 grid-cols-7 gap-x-2 gap-y-3`}>
+        {Array.from({ length: getDaysInMonth(calenderDate) })
+          .fill(0)
+          .map((_, index) => (
+            <motion.div
+              layout
+              key={`$day-${index + 1}`}
+              className={cn('flex h-full w-full flex-col')}
+              style={{ gridColumnStart: index === 0 ? firstDayOfWeek : undefined }}>
+              <span className="ml-1">{index + 1}</span>
+              <div className="flex-1 rounded-lg bg-gray-100"></div>
+            </motion.div>
+          ))}
+      </div>
+    </div>
+  );
+}
+
+function AllArchivingView() {
+  return (
+    <div className="w-full border">
+      {/* TODO: 나중에 스크롤 애니메이션 달아보기 */}
+      <div className="w-full bg-white p-5">
+        <button className="w-full rounded-lg bg-gray-100 py-2">필터</button>
+      </div>
+
+      <div className="grid w-full grid-cols-3 gap-1">
+        {Array.from({ length: 13 })
+          .fill(0)
+          .map(() => (
+            <div className="group aspect-[3/4] w-full cursor-pointer overflow-hidden rounded-lg">
+              <div
+                style={{ backgroundImage: `url('${testImage}')` }}
+                className="h-full w-full bg-cover bg-center bg-no-repeat transition-transform group-hover:scale-105"
+              />
+            </div>
+          ))}
+      </div>
+    </div>
+  );
 }

--- a/src/pages/Root/voteFAP/page.tsx
+++ b/src/pages/Root/voteFAP/page.tsx
@@ -16,7 +16,7 @@ export default function Page() {
   });
 
   return (
-    <FlexibleLayout.Root className="gap-3">
+    <FlexibleLayout.Root className="gap-3 p-5">
       <FlexibleLayout.Header>
         <VotingCounter />
       </FlexibleLayout.Header>

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -2,6 +2,7 @@ import { LoaderResponse, LoaderResponseStatus } from '@Types/loaderResponse';
 import { ServiceErrorResponse } from '@Types/serviceError';
 import { isAxiosError } from 'axios';
 import { type ClassValue, clsx } from 'clsx';
+import { isAfter, isBefore, isSameMonth, isSameYear } from 'date-fns';
 import { sha256 } from 'js-sha256';
 import { twMerge } from 'tailwind-merge';
 
@@ -160,4 +161,15 @@ export async function prefetchImages(images: string[]): Promise<void> {
         })
     )
   );
+}
+export function isBetweenDate(pre: Date, cur: Date, post: Date) {
+  return sameOrAfter(cur, pre) && sameOrBefore(cur, post);
+}
+
+export function sameOrBefore(d1 = new Date(), d2 = new Date()) {
+  return isSameYear(d1, d2) && isSameMonth(d1, d2) ? true : isBefore(d1, d2) ? true : false;
+}
+
+export function sameOrAfter(d1 = new Date(), d2 = new Date()) {
+  return isSameYear(d1, d2) && isSameMonth(d1, d2) ? true : isAfter(d1, d2) ? true : false;
 }


### PR DESCRIPTION
### 관련된 이슈 번호를 기입해주세요.
> `close #이슈번호` 와 같은 형식으로 작성해주세요.

- close #102 

### 어떤 부분이 변경됐나요?
> 어떤 부분을 변경했는지, 무슨 이유로 코드를 변경했는지 설명해주세요.

**아카이브 탭 화면을 구성했어요.**
- 페이피 아카이브 탭 화면을 작성했어요.
  - 캘린더 컴포넌트를 작성했어요.
  - 날짜 선택 Date Picker를 적용했어요.
    - 근데 이거 개발할 때 호환성이 너무 안 좋아서 ;; 나중에 바꾸긴 해야 할 듯
- 패션 전체보기 탭 화면을 작성했어요.
  - 상단의 필터 영역은 스크롤 액션에 따라 보여지고 숨겨지고 싶었는데,, 지금 이거 구조가 너무 이상해서 ㅜㅜ 일단 넘어갑니다

| FA:P 아카이브 화면 | 패션 전체보기 화면 |
| --- | --- |
| ![image](https://github.com/user-attachments/assets/69cffa0d-9d95-4ff6-bf45-b9339ddd3fab) | ![image](https://github.com/user-attachments/assets/055ef29a-36bc-414c-9e8f-6880c0bf2a5b) |

**간단한 애니메이션을 적용했어요.**
- 탭 인디케이터 애니메이션 적용

![GIF 2024-07-24 오후 7-02-10](https://github.com/user-attachments/assets/e90bd904-7616-4fe0-bfca-b971e5eb18f4)

- 화면 전환 트렌지션 적용

![GIF 2024-07-24 오후 7-03-21](https://github.com/user-attachments/assets/40a8e02c-ae96-410a-b8c5-2d16c3ed6528)

- 캘린더 애니메이션 적용
  - 좀 정신없나 싶기도 해서 위와 같이 화면 전환 트렌지션을 적용할까 싶기도 합니다!

![GIF 2024-07-24 오후 7-04-17](https://github.com/user-attachments/assets/a66a1a75-756e-4ed4-89b4-a2d18d1761b5)

### 추가 정보 (선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.

- 사파리에서 showPicker()는 안 먹힌다는 사실 ...
- 아직 달력 넘기는 부분은 기능적으로 보완 필요합니다