### PR TITLE
마이페이지/계정 관리/회원 탈퇴 화면 작성

### DIFF
--- a/src/components/ConfirmModal.tsx
+++ b/src/components/ConfirmModal.tsx
@@ -10,7 +10,7 @@ type ConfirmProps = {
 export function ConfirmModal({ title, description, onClose }: DefaultModalProps<boolean, ConfirmProps>) {
   return (
     <FlexibleLayout.Root className="h-fit">
-      <FlexibleLayout.Content className="pt-10">
+      <FlexibleLayout.Content className="p-5 pt-10">
         <div className="space-y-8">
           <MdWarning className="mx-auto size-24 text-purple-100" />
 

--- a/src/pages/Root/mypage/components/AccountSetting.tsx
+++ b/src/pages/Root/mypage/components/AccountSetting.tsx
@@ -2,6 +2,7 @@ import { Form, FormControl, FormField, FormItem, FormMessage } from '@/component
 import testImage from '@Assets/test_fashion_image.jpg';
 import { Input } from '@Components/ui/Input';
 import { zodResolver } from '@hookform/resolvers/zod';
+import { useModalActions } from '@Hooks/modal';
 import { FlexibleLayout } from '@Layouts/FlexibleLayout';
 import * as RadioGroup from '@radix-ui/react-radio-group';
 import { DefaultModalProps } from '@Stores/modal';
@@ -10,6 +11,7 @@ import { useTransition } from 'react';
 import { Control, useForm } from 'react-hook-form';
 import { MdCameraAlt, MdChevronLeft } from 'react-icons/md';
 import { z } from 'zod';
+import ResignServiceView from './ResignServiceView';
 
 export default function AccountSetting({ onClose }: DefaultModalProps) {
   return (
@@ -89,6 +91,7 @@ function InitializeAccountForm({ onSubmit }: { onSubmit: (values: InitializeAcco
     </Form>
   );
 }
+
 function BackButton({ onClick }: { onClick: () => void }) {
   return (
     <button
@@ -161,10 +164,18 @@ function SexField({ control }: { control: Control<InitializeAccountFormSchema> }
 }
 
 function ResignButton() {
+  const { showModal } = useModalActions();
+
+  const handleClick = async () => {
+    await showModal({ type: 'fullScreenDialog', Component: ResignServiceView, animateType: 'slideInFromRight' });
+  };
+
   return (
     <div className="space-y-1 p-1">
       <p className="text-h6 font-semibold">회원 탈퇴</p>
-      <button className="font-semibold text-gray-500 underline">페이드 서비스에서 탈퇴하기</button>
+      <button className="font-semibold text-gray-500 underline" onClick={handleClick}>
+        페이드 서비스에서 탈퇴하기
+      </button>
     </div>
   );
 }

--- a/src/pages/Root/mypage/components/AccountSetting.tsx
+++ b/src/pages/Root/mypage/components/AccountSetting.tsx
@@ -1,0 +1,170 @@
+import { Form, FormControl, FormField, FormItem, FormMessage } from '@/components/ui/form';
+import testImage from '@Assets/test_fashion_image.jpg';
+import { Input } from '@Components/ui/Input';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { FlexibleLayout } from '@Layouts/FlexibleLayout';
+import * as RadioGroup from '@radix-ui/react-radio-group';
+import { DefaultModalProps } from '@Stores/modal';
+import { cn } from '@Utils/index';
+import { useTransition } from 'react';
+import { Control, useForm } from 'react-hook-form';
+import { MdCameraAlt, MdChevronLeft } from 'react-icons/md';
+import { z } from 'zod';
+
+export default function AccountSetting({ onClose }: DefaultModalProps) {
+  return (
+    <FlexibleLayout.Root>
+      <FlexibleLayout.Header>
+        <header className="relative px-5 py-4">
+          <BackButton onClick={onClose} />
+          <p className="text-center text-2xl font-semibold">계정 관리</p>
+        </header>
+      </FlexibleLayout.Header>
+
+      <FlexibleLayout.Content className="flex flex-col p-5">
+        <div className="py-10">
+          <div style={{ backgroundImage: `url('${testImage}')` }} className="relative mx-auto size-32 rounded-lg bg-cover bg-center bg-no-repeat">
+            <button className="absolute bottom-0 right-0 translate-x-1/3 translate-y-1/3 rounded-full bg-gray-100 p-1">
+              <MdCameraAlt className="size-5 text-gray-400" />
+            </button>
+          </div>
+        </div>
+
+        <InitializeAccountForm onSubmit={() => {}} />
+      </FlexibleLayout.Content>
+    </FlexibleLayout.Root>
+  );
+}
+
+const accountIdRegExp = new RegExp(/^[a-zA-Z0-9._]{4,15}$/);
+
+const formSchema = z.object({
+  accountId: z.string().regex(accountIdRegExp, '사용할 수 없는 ID입니다.'),
+  sex: z.enum(['men', 'women'], { message: '성별을 선택해주세요.' }),
+});
+
+type InitializeAccountFormSchema = z.infer<typeof formSchema>;
+
+function InitializeAccountForm({ onSubmit }: { onSubmit: (values: InitializeAccountFormSchema) => void }) {
+  const [pending, startTransition] = useTransition();
+
+  const form = useForm<InitializeAccountFormSchema>({
+    resolver: zodResolver(formSchema),
+    defaultValues: {
+      accountId: '',
+      sex: 'men',
+    },
+    mode: 'onChange',
+  });
+
+  const { isValid, errors } = form.formState;
+  const couldSubmit = isValid && !pending;
+
+  function handleSubmitAfterValidation(values: InitializeAccountFormSchema) {
+    startTransition(() => {
+      onSubmit(values);
+    });
+  }
+
+  return (
+    <Form {...form}>
+      <form onSubmit={form.handleSubmit(handleSubmitAfterValidation)} className="flex-1 space-y-8">
+        <fieldset className="flex h-full flex-col gap-5" disabled={pending}>
+          <div className="flex flex-1 flex-col gap-5">
+            <AccountIdField control={form.control} invalid={!!errors?.accountId} />
+            <SexField control={form.control} />
+            <ResignButton />
+          </div>
+
+          <button
+            className="group w-full self-end rounded-lg bg-purple-500 py-3 text-xl font-semibold text-white transition-colors disabled:cursor-not-allowed disabled:bg-gray-200 disabled:text-gray-400"
+            disabled={!couldSubmit}
+            aria-disabled={!couldSubmit}>
+            <span className="inline-block transition-transform group-aria-[disabled=false]:touchdevice:group-active:scale-95 group-aria-[disabled=false]:pointerdevice:group-hover:scale-105 group-aria-[disabled=false]:pointerdevice:group-active:scale-95">
+              FADE 시작하기
+            </span>
+          </button>
+        </fieldset>
+      </form>
+    </Form>
+  );
+}
+function BackButton({ onClick }: { onClick: () => void }) {
+  return (
+    <button
+      className="group absolute left-3 top-1/2 -translate-y-1/2 cursor-pointer rounded-lg p-2 touchdevice:active:bg-gray-100 pointerdevice:hover:bg-gray-100"
+      onClick={onClick}>
+      <MdChevronLeft className="size-6 transition-transform touchdevice:group-active:scale-95 pointerdevice:group-active:scale-95" />
+    </button>
+  );
+}
+
+function AccountIdField({ control, invalid }: { control: Control<InitializeAccountFormSchema>; invalid: boolean }) {
+  return (
+    <FormField
+      control={control}
+      name="accountId"
+      render={({ field }) => (
+        <FormItem className="space-y-1">
+          <p className="text-h6 font-semibold">계정 ID</p>
+          <FormControl>
+            <Input placeholder="계정 ID" {...field} className="peer aria-[invalid=true]:border-pink-400" />
+          </FormControl>
+
+          <div className="pl-1 text-xs text-gray-600">
+            {invalid && <FormMessage className="text-xs text-pink-400" />}
+            {!invalid && field.value === '' && <p>사용할 계정 ID를 입력해주세요.</p>}
+            {!invalid && field.value !== '' && <p>사용할 수 있는 ID입니다.</p>}
+
+            <ul className={cn('list-disc pl-5', { ['text-pink-400']: invalid })}>
+              <li>영문자, 숫자, 마침표 및 밑줄만 사용 가능</li>
+              <li>최소 4자, 최대 30자</li>
+            </ul>
+          </div>
+        </FormItem>
+      )}
+    />
+  );
+}
+
+function SexField({ control }: { control: Control<InitializeAccountFormSchema> }) {
+  return (
+    <FormField
+      control={control}
+      name="sex"
+      render={({ field }) => (
+        <FormItem className="space-y-1">
+          <p className="text-h6 font-semibold">성별</p>
+
+          <FormControl>
+            <RadioGroup.Root defaultValue="men" className="flex w-full flex-row gap-5" value={field.value} onValueChange={field.onChange}>
+              <RadioGroup.Item
+                value="men"
+                className="flex flex-1 items-center justify-center rounded-lg bg-gray-200 py-3 text-black transition-colors data-[state=checked]:bg-violet-500 data-[state=checked]:text-white">
+                <p>남자</p>
+              </RadioGroup.Item>
+              <RadioGroup.Item
+                value="women"
+                className="flex flex-1 items-center justify-center rounded-lg bg-gray-200 py-3 text-black transition-colors data-[state=checked]:bg-violet-500 data-[state=checked]:text-white">
+                <p>여자</p>
+              </RadioGroup.Item>
+            </RadioGroup.Root>
+          </FormControl>
+
+          <p className="pl-1 text-xs text-gray-600">성별을 선택해주세요. 사진의 필터링에 활용되니 사실과 같게 선택해주세요!</p>
+
+          <FormMessage className="text-pink-400" />
+        </FormItem>
+      )}
+    />
+  );
+}
+
+function ResignButton() {
+  return (
+    <div className="space-y-1 p-1">
+      <p className="text-h6 font-semibold">회원 탈퇴</p>
+      <button className="font-semibold text-gray-500 underline">페이드 서비스에서 탈퇴하기</button>
+    </div>
+  );
+}

--- a/src/pages/Root/mypage/components/ResignServiceView.tsx
+++ b/src/pages/Root/mypage/components/ResignServiceView.tsx
@@ -1,0 +1,207 @@
+import { FlexibleLayout } from '@Layouts/FlexibleLayout';
+import { DefaultModalProps } from '@Stores/modal';
+import * as RadioGroup from '@radix-ui/react-radio-group';
+import { PropsWithChildren, useState } from 'react';
+import { motion } from 'framer-motion';
+import { MdChevronLeft, MdChevronRight } from 'react-icons/md';
+import { cn } from '@Utils/index';
+import { useConfirm } from '@Hooks/modal';
+
+const resignReasonTexts = [
+  '서비스를 더 이상 이용하지 않아요.',
+  '서비스에 너무 많은 시간을 소요해요.',
+  '얻고 싶은 정보를 얻을 수 없어요.',
+  '비매너 유저가 많아요.',
+  '탈퇴 후 재가입하고 싶어요.',
+  '기타',
+];
+
+type TResignReason = {
+  type: string;
+  detail: string;
+};
+
+export default function ResignServiceView({ onClose }: DefaultModalProps) {
+  const [viewId, setViewId] = useState(0);
+  const confirm = useConfirm();
+
+  const isSelectView = viewId === 0;
+  const isConfirmView = viewId === 1;
+
+  const [resignReason, setResignReason] = useState<TResignReason>({ type: '0', detail: '' });
+  const isOtherSelected = +resignReason.type === resignReasonTexts.length - 1;
+  const isDetailInputed = resignReason.detail !== '';
+
+  const [isConfirm, setIsConfirm] = useState(false);
+
+  const isNotConfirmed = isConfirmView && !isConfirm;
+  const doesNotInputOtherDetail = isSelectView && isOtherSelected && !isDetailInputed;
+  const wouldCTADisabled = isNotConfirmed || doesNotInputOtherDetail;
+
+  const handleCTAClick = async () => {
+    if (isSelectView) {
+      return setViewId(1);
+    }
+
+    await confirm({ title: '잠깐만요.. 정말 탈퇴하시겠어요?', description: '탈퇴 이후 재가입이 불가능하며 동일한 계정 ID의 사용이 불가합니다.' });
+  };
+
+  return (
+    <FlexibleLayout.Root>
+      <FlexibleLayout.Header>
+        <header className="relative px-5 py-4">
+          <BackButton onClick={onClose} />
+          <p className="text-center text-2xl font-semibold">계정 관리</p>
+        </header>
+      </FlexibleLayout.Header>
+
+      <FlexibleLayout.Content>
+        {isSelectView && (
+          <ResignReasonSelectView
+            isOtherSelected={isOtherSelected}
+            resignReason={resignReason}
+            onReasonUpdate={(field) => setResignReason((prev) => ({ ...prev, ...field }))}
+          />
+        )}
+        {isConfirmView && <ResignConfirmView isConfirm={isConfirm} onConfirmToggle={() => setIsConfirm(!isConfirm)} />}
+      </FlexibleLayout.Content>
+
+      <FlexibleLayout.Footer>
+        <div className="p-5">
+          <button
+            onClick={handleCTAClick}
+            disabled={wouldCTADisabled}
+            className={cn('w-full rounded-lg bg-black py-2 text-h5 text-white transition-colors disabled:bg-gray-200 disabled:text-gray-400', {
+              ['bg-pink-600']: isConfirmView,
+            })}>
+            {isSelectView && '다음'}
+            {isConfirmView && 'FADE에서 탈퇴하기'}
+          </button>
+        </div>
+      </FlexibleLayout.Footer>
+    </FlexibleLayout.Root>
+  );
+}
+
+function BackButton({ onClick }: { onClick: () => void }) {
+  return (
+    <button
+      className="group absolute left-3 top-1/2 -translate-y-1/2 cursor-pointer rounded-lg p-2 touchdevice:active:bg-gray-100 pointerdevice:hover:bg-gray-100"
+      onClick={onClick}>
+      <MdChevronLeft className="size-6 transition-transform touchdevice:group-active:scale-95 pointerdevice:group-active:scale-95" />
+    </button>
+  );
+}
+
+function ResignReasonSelectView({
+  resignReason,
+  isOtherSelected,
+  onReasonUpdate,
+}: {
+  resignReason: TResignReason;
+  isOtherSelected: boolean;
+  onReasonUpdate: (fields: Partial<TResignReason>) => void;
+}) {
+  const textLength = resignReason.detail?.length || 0;
+
+  return (
+    <div className="p-5">
+      <p className="text-h3 font-semibold">탈퇴 사유를 선택해주세요</p>
+      <RadioGroup.Root defaultValue="men" className="flex w-full flex-col" value={resignReason.type} onValueChange={(value) => onReasonUpdate({ type: value })}>
+        {resignReasonTexts.map((resignReasonText, index) => (
+          <ResignReasonItem value={String(index)} reason={resignReasonText} />
+        ))}
+
+        <div
+          className="group flex h-20 w-full resize-none flex-col rounded-lg bg-gray-100 p-3 transition-colors aria-disabled:bg-gray-300"
+          aria-disabled={!isOtherSelected}>
+          <textarea
+            className="h-full w-full resize-none bg-transparent align-text-top outline-none transition-colors disabled:bg-gray-300 disabled:text-gray-500"
+            placeholder="상세 사유를 입력해주세요."
+            value={resignReason.detail || ''}
+            onChange={(e) => onReasonUpdate({ detail: e.target.value })}
+            maxLength={100}
+            disabled={!isOtherSelected}
+          />
+          <p className="text-right text-xs text-gray-400">{textLength > 100 ? 100 : textLength} / 100</p>
+        </div>
+      </RadioGroup.Root>
+    </div>
+  );
+}
+
+function ResignReasonItem({ value, reason }: { value: string; reason: string }) {
+  return (
+    <RadioGroup.Item value={value} className="group flex flex-row items-center space-x-2 py-5">
+      <div className="grid size-6 place-items-center rounded-full border border-purple-100 bg-purple-50 transition-colors group-data-[state='checked']:border-purple-500 group-data-[state='checked']:bg-purple-500">
+        <RadioGroup.Indicator className={`block size-2 rounded-full group-data-[state='checked']:bg-white`} />
+      </div>
+
+      <p>{reason}</p>
+    </RadioGroup.Item>
+  );
+}
+
+function ResignConfirmView({ isConfirm, onConfirmToggle }: { isConfirm: boolean; onConfirmToggle: () => void }) {
+  return (
+    <div className="space-y-2 p-5">
+      <p className="text-h3 font-semibold">탈퇴 후 정보 처리 고지</p>
+
+      <ol className="list-decimal pl-[1rem] text-h6">
+        <li>소셜 로그인 정보 삭제(로그인 연동 해제) </li>
+        <li>성별 정보 삭제 </li>
+        <li>앱 내 올린 모든 사진 및 북마크, 구독 목록 등 삭제</li>
+        <li>계정 ID 보관 (추후 같은 ID로 재가입 불가)</li>
+        <li>자동으로 수집되는 방문 정보 보관</li>
+      </ol>
+
+      <ToggleTosButton isActive={isConfirm} onClick={onConfirmToggle} hasRightIcon={false}>
+        확인했습니다.
+      </ToggleTosButton>
+    </div>
+  );
+}
+
+type ToogleButtonProps = {
+  isActive: boolean;
+  isRequired?: boolean;
+  hasRightIcon?: boolean;
+  onClick: () => void;
+};
+
+function ToggleTosButton({ isActive, onClick, isRequired = true, hasRightIcon = true, children }: PropsWithChildren<ToogleButtonProps>) {
+  return (
+    <button className="mx-auto flex w-fit flex-row gap-2 px-5 py-4" onClick={onClick}>
+      <div
+        className={cn('rounded-full border border-purple-100 bg-purple-50 transition-colors', {
+          ['border-purple-500 bg-purple-500 text-white']: isActive,
+        })}>
+        <CheckIcon isActive={isActive} />
+      </div>
+
+      <div className="flex flex-1 flex-row items-center justify-center space-x-1">
+        {isRequired && <p className="min-w-fit text-purple-200">(필수)</p>}
+        <p className="w-full text-left">{children}</p>
+      </div>
+
+      {hasRightIcon && <MdChevronRight className="size-6 text-purple-200" />}
+    </button>
+  );
+}
+
+function CheckIcon({ isActive }: { isActive: boolean }) {
+  return (
+    <div className="grid size-6 place-items-center">
+      <svg width="16" height="12" viewBox="0 0 16 12" fill="none" xmlns="http://www.w3.org/2000/svg">
+        <motion.path
+          animate={{ pathLength: isActive ? 1 : 0, opacity: isActive ? 1 : 0 }}
+          d="M2 6L6.5 10L14 2"
+          stroke="white"
+          strokeWidth="3"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+      </svg>
+    </div>
+  );
+}

--- a/src/pages/Root/mypage/page.tsx
+++ b/src/pages/Root/mypage/page.tsx
@@ -1,7 +1,95 @@
+import testImage from '@Assets/test_fashion_image.jpg';
 import { useHeader } from '@Hooks/useHeader';
+import { IconType } from 'react-icons/lib';
+import { MdBook, MdBookmark, MdHowToVote, MdOutlineNotificationsNone, MdPerson } from 'react-icons/md';
+
+type MyPageMenu = {
+  id: number;
+  type: 'subpage' | 'dialog';
+  path: string | null;
+  IconComponent: IconType;
+  name: string;
+};
+
+const mypageMenus: MyPageMenu[] = [
+  {
+    id: 0,
+    type: 'subpage',
+    path: '/mypage/feed',
+    IconComponent: MdPerson,
+    name: '내 피드',
+  },
+  {
+    id: 1,
+    type: 'subpage',
+    path: '/mypage/vote-history',
+    IconComponent: MdHowToVote,
+    name: '투표 내역',
+  },
+  {
+    id: 2,
+    type: 'subpage',
+    path: '/mypage/bookmark',
+    IconComponent: MdBookmark,
+    name: '북마크',
+  },
+  {
+    id: 3,
+    type: 'dialog',
+    path: null,
+    IconComponent: MdBook,
+    name: '서비스 정책',
+  },
+];
 
 export default function Page() {
-  useHeader({ title: '마이페이지' });
+  useHeader({ title: '마이페이지', rightSlot: () => <ShowNotificationButton /> });
 
-  return <>마이 페이지</>;
+  const handleMenuClick = ({ path, type }: MyPageMenu) => {
+    console.log({ path, type });
+  };
+
+  return (
+    <div className="flex h-full flex-col bg-gray-100">
+      <div className="flex flex-col items-center justify-center gap-5 rounded-b-2xl bg-white pb-5 pt-10">
+        <div style={{ backgroundImage: `url('${testImage}')` }} className="size-32 rounded-lg bg-cover bg-center bg-no-repeat" />
+
+        <div className="flex flex-col items-center justify-center gap-1">
+          <p className="text-h4 font-semibold">안녕하세요, FADE_1234님!</p>
+
+          <div className="space-x-1 text-detail">
+            <span className="text-gray-500">여자</span>
+            <span>·</span>
+            <span>FA:P 선정 0회</span>
+          </div>
+        </div>
+
+        <button className="rounded-2xl border border-gray-200 bg-white px-4 py-3 text-detail">계정 관리</button>
+      </div>
+
+      <div className="flex min-h-1 flex-1 flex-col border border-red-400">
+        <ul className="min-h-1 flex-1 space-y-3 overflow-y-scroll px-5 py-3">
+          {mypageMenus.map((menuItem) => (
+            <li key={`menu-${menuItem.id}`} onClick={() => handleMenuClick(menuItem)} className="flex cursor-pointer flex-row gap-1 rounded-lg bg-white px-5 py-3">
+              <menuItem.IconComponent className="size-5 text-purple-500" />
+              <span>{menuItem.name}</span>
+            </li>
+          ))}
+        </ul>
+
+        <div className="flex flex-col items-center justify-center py-1">
+          <button className="font-semibold underline">로그아웃</button>
+          <p className="text-detail text-gray-500">FADE팀 admin@fade.com</p>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function ShowNotificationButton() {
+  return (
+    <button className="group relative cursor-pointer rounded-lg p-2 touchdevice:active:bg-gray-100 pointerdevice:hover:bg-gray-100">
+      <MdOutlineNotificationsNone className="size-6 transition-transform touchdevice:group-active:scale-95 pointerdevice:group-active:scale-95" />
+    </button>
+  );
 }

--- a/src/pages/Root/mypage/page.tsx
+++ b/src/pages/Root/mypage/page.tsx
@@ -1,9 +1,10 @@
 import testImage from '@Assets/test_fashion_image.jpg';
-import { useConfirm } from '@Hooks/modal';
+import { useConfirm, useModalActions } from '@Hooks/modal';
 import { useHeader } from '@Hooks/useHeader';
 import { IconType } from 'react-icons/lib';
 import { MdBook, MdBookmark, MdHowToVote, MdOutlineNotificationsNone, MdPerson } from 'react-icons/md';
 import { useNavigate } from 'react-router-dom';
+import AccountSetting from './components/AccountSetting';
 
 type MyPageMenu = {
   id: number;
@@ -66,7 +67,7 @@ export default function Page() {
           </div>
         </div>
 
-        <button className="rounded-2xl border border-gray-200 bg-white px-4 py-3 text-detail">계정 관리</button>
+        <ManageAccountButton />
       </div>
 
       <div className="flex min-h-1 flex-1 flex-col border border-red-400">
@@ -89,6 +90,20 @@ function ShowNotificationButton() {
   return (
     <button className="group relative cursor-pointer rounded-lg p-2 touchdevice:active:bg-gray-100 pointerdevice:hover:bg-gray-100">
       <MdOutlineNotificationsNone className="size-6 transition-transform touchdevice:group-active:scale-95 pointerdevice:group-active:scale-95" />
+    </button>
+  );
+}
+
+function ManageAccountButton() {
+  const { showModal } = useModalActions();
+
+  const handleClick = async () => {
+    await showModal({ type: 'fullScreenDialog', animateType: 'slideInFromRight', Component: AccountSetting });
+  };
+
+  return (
+    <button className="rounded-2xl border border-gray-200 bg-white px-4 py-3 text-detail" onClick={handleClick}>
+      계정 관리
     </button>
   );
 }

--- a/src/pages/Root/mypage/page.tsx
+++ b/src/pages/Root/mypage/page.tsx
@@ -1,7 +1,9 @@
 import testImage from '@Assets/test_fashion_image.jpg';
+import { useConfirm } from '@Hooks/modal';
 import { useHeader } from '@Hooks/useHeader';
 import { IconType } from 'react-icons/lib';
 import { MdBook, MdBookmark, MdHowToVote, MdOutlineNotificationsNone, MdPerson } from 'react-icons/md';
+import { useNavigate } from 'react-router-dom';
 
 type MyPageMenu = {
   id: number;
@@ -77,10 +79,7 @@ export default function Page() {
           ))}
         </ul>
 
-        <div className="flex flex-col items-center justify-center py-1">
-          <button className="font-semibold underline">로그아웃</button>
-          <p className="text-detail text-gray-500">FADE팀 admin@fade.com</p>
-        </div>
+        <LogoutButton />
       </div>
     </div>
   );
@@ -91,5 +90,26 @@ function ShowNotificationButton() {
     <button className="group relative cursor-pointer rounded-lg p-2 touchdevice:active:bg-gray-100 pointerdevice:hover:bg-gray-100">
       <MdOutlineNotificationsNone className="size-6 transition-transform touchdevice:group-active:scale-95 pointerdevice:group-active:scale-95" />
     </button>
+  );
+}
+
+function LogoutButton() {
+  const navigate = useNavigate();
+  const confirm = useConfirm();
+
+  const handleClick = async () => {
+    const result = await confirm({ title: '로그아웃 하시겠습니까?', description: '언제든 다시 로그인 할 수 있어요.' });
+
+    result && navigate('/auth/signout', { replace: true });
+  };
+
+  return (
+    <div className="flex flex-col items-center justify-center py-1">
+      <button className="font-semibold underline" onClick={handleClick}>
+        로그아웃
+      </button>
+
+      <p className="text-detail text-gray-500">FADE팀 admin@fade.com</p>
+    </div>
   );
 }


### PR DESCRIPTION
### 관련된 이슈 번호를 기입해주세요.
> `close #이슈번호` 와 같은 형식으로 작성해주세요.

- close #109 

### 어떤 부분이 변경됐나요?
> 어떤 부분을 변경했는지, 무슨 이유로 코드를 변경했는지 설명해주세요.

**마이페이지/계정 관리/ 회원 탈퇴 화면을 작성했어요.**
- 각각의 화면은 아래와 같아요.

| 마이페이지 | 계정 관리 | 회원 탈퇴 | 
| --- | --- | --- |
| ![image](https://github.com/user-attachments/assets/1bd8ab0c-cf8a-44a5-8d42-9151a7e00f22) | ![image](https://github.com/user-attachments/assets/78d0c974-7c02-4ef3-8a36-739a803fc920) | ![image](https://github.com/user-attachments/assets/1bea3eb6-0622-43af-9c14-7a1ac2dd4385) |

**마이페이지 관련**
- 로그아웃 Confirm 호출
- 계정 관리 버튼 기능 추가

**계정 관리 관련**
- 기존 계정 초기 설정 폼과 같습니다.
  - 다른 곳에서도 쓸 수 있게 공통 컴포넌트로 뺄 예정입니다.
- 회원 탈퇴 기능 추가 

**회원 탈퇴 관련**
- 기타 사유를 선택 시 상세 사유를 적어야 버튼이 활성화됩니다.
- 탈퇴 후 정보 처리 고지에 확인해야 버튼이 활성화됩니다.
- 탈퇴하기 버튼 클릭 시 Confirm 호출


### 추가 정보 (선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.

- 기능은 일단 후순위로 미뤘습니다!
- 그리고 이곳저곳에서 컴포넌트를 가져다가 쓰다보니 코드가 좀 중복이 많아졌는데, 이 부분도 나중에 리팩토링 예정입니다.
