### PR TITLE
알림 페이지 화면 구현

### DIFF
--- a/src/components/NotificationDialog.tsx
+++ b/src/components/NotificationDialog.tsx
@@ -1,0 +1,155 @@
+import { FlexibleLayout } from '@Layouts/FlexibleLayout';
+import { DefaultModalProps } from '@Stores/modal';
+import {
+  isFAPDeletedNotification,
+  isFAPSelectedNotification,
+  isFeedDeletedNotification,
+  isFeedReportedNotification,
+  NotificationDataMap,
+  TNotification,
+} from '@Types/notification';
+import { cn, getRelativeTimeLabel } from '@Utils/index';
+import { subDays, subMonths } from 'date-fns';
+import { FaCrown } from 'react-icons/fa6';
+import { MdCancel, MdChevronLeft, MdChevronRight, MdDelete, MdReport } from 'react-icons/md';
+
+const testNotis: TNotification[] = [
+  {
+    type: 'FEED_REPORTED',
+    feedId: 0,
+    reportCount: 3,
+    isRead: false,
+    createdAt: subDays(new Date(), 0),
+  },
+  {
+    type: 'FEED_DELETED',
+    isRead: false,
+    createdAt: subDays(new Date(), 1),
+  },
+  {
+    type: 'FAP_SELECTED',
+    selectedDate: '7월 21일',
+    isRead: false,
+    createdAt: subDays(new Date(), 2),
+  },
+  {
+    type: 'FEED_REPORTED',
+    feedId: 0,
+    reportCount: 2,
+    isRead: true,
+    createdAt: subDays(new Date(), 3),
+  },
+  {
+    type: 'FAP_SELECTED',
+    selectedDate: '7월 19일',
+    isRead: true,
+    createdAt: subDays(new Date(), 10),
+  },
+  {
+    type: 'FEED_DELETED',
+    isRead: true,
+    createdAt: subDays(new Date(), 11),
+  },
+  {
+    type: 'FEED_DELETED',
+    isRead: true,
+    createdAt: subDays(new Date(), 12),
+  },
+  {
+    type: 'FAP_DELETED',
+    deletedFAPCount: 1,
+    isRead: true,
+    createdAt: subDays(new Date(), 20),
+  },
+  {
+    type: 'FAP_SELECTED',
+    selectedDate: '6월 19일',
+    isRead: true,
+    createdAt: subMonths(new Date(), 1),
+  },
+];
+
+export function NotificationDialog({ onClose }: DefaultModalProps) {
+  return (
+    <FlexibleLayout.Root>
+      <FlexibleLayout.Header>
+        <header className="relative px-5 py-4">
+          <BackButton onClick={onClose} />
+          <p className="text-center text-2xl font-semibold">알림</p>
+        </header>
+      </FlexibleLayout.Header>
+
+      <FlexibleLayout.Content className="space-y-3 bg-gray-100 p-5">
+        <ul className="flex flex-col gap-3">
+          {testNotis.map((noti, index) => (
+            <NotificationItem key={`noti-${index}`} {...noti} />
+          ))}
+        </ul>
+
+        <p className="text-detail text-gray-500">알림은 한 달이 지나면 자동으로 사라져요!</p>
+      </FlexibleLayout.Content>
+    </FlexibleLayout.Root>
+  );
+}
+
+function BackButton({ onClick }: { onClick: () => void }) {
+  return (
+    <button
+      className="group absolute left-4 top-1/2 -translate-y-1/2 cursor-pointer rounded-lg p-2 touchdevice:active:bg-gray-100 pointerdevice:hover:bg-gray-100"
+      onClick={onClick}>
+      <MdChevronLeft className="size-6 transition-transform group-active:scale-95" />
+    </button>
+  );
+}
+
+const notiDatas: NotificationDataMap = {
+  FEED_REPORTED: {
+    IconComponent: MdReport,
+    iconColor: 'text-pink-400',
+    getMessage: (count: number) => `내 사진에 대한 신고가 있어요. (${count}/5)`,
+  },
+  FEED_DELETED: {
+    IconComponent: MdDelete,
+    iconColor: 'text-purple-500',
+    getMessage: () => '신고 5회 누적으로 사진이 삭제되었습니다.',
+  },
+  FAP_SELECTED: {
+    IconComponent: FaCrown,
+    iconColor: 'text-yellow-800',
+    getMessage: (date: string) => `축하합니다! ${date}의 FA:P에 선정되었어요🎉`,
+  },
+  FAP_DELETED: {
+    IconComponent: MdCancel,
+    iconColor: 'text-pink-400',
+    getMessage: (count: number) => `FA:P에 선정된 사진을 삭제했어요. (${count}/3)`,
+  },
+};
+
+function NotificationItem(notification: TNotification) {
+  const { type, isRead } = notification;
+  const { IconComponent, iconColor } = notiDatas[type];
+
+  const isFeedReported = type === 'FEED_REPORTED';
+
+  return (
+    <li
+      className={cn('flex flex-row items-center gap-3 rounded-lg bg-white px-5 py-3', {
+        ['bg-purple-50']: !isRead,
+        ['cursor-pointer']: isFeedReported,
+      })}>
+      {}
+      <IconComponent className={`size-6 ${iconColor}`} />
+      <div className="flex flex-1 flex-col">
+        <p className="text-body">
+          {isFeedReportedNotification(notification) && notiDatas[notification.type].getMessage(notification.reportCount)}
+          {isFeedDeletedNotification(notification) && notiDatas[notification.type].getMessage()}
+          {isFAPSelectedNotification(notification) && notiDatas[notification.type].getMessage(notification.selectedDate)}
+          {isFAPDeletedNotification(notification) && notiDatas[notification.type].getMessage(notification.deletedFAPCount)}
+        </p>
+        {<span className="text-detail text-gray-500">{getRelativeTimeLabel(notification.createdAt)}</span>}
+      </div>
+
+      {isFeedReported && <MdChevronRight className="size-6 text-gray-500" />}
+    </li>
+  );
+}

--- a/src/components/ShowNotificationButton.tsx
+++ b/src/components/ShowNotificationButton.tsx
@@ -1,0 +1,17 @@
+import { useModalActions } from '@Hooks/modal';
+import { MdOutlineNotificationsNone } from 'react-icons/md';
+import { NotificationDialog } from './NotificationDialog';
+
+export function ShowNotificationButton() {
+  const { showModal } = useModalActions();
+
+  const handleClick = async () => {
+    await showModal({ type: 'fullScreenDialog', animateType: 'slideInFromRight', Component: NotificationDialog });
+  };
+
+  return (
+    <button className="group relative cursor-pointer rounded-lg p-2 touchdevice:active:bg-gray-100 pointerdevice:hover:bg-gray-100" onClick={handleClick}>
+      <MdOutlineNotificationsNone className="size-6 transition-transform touchdevice:group-active:scale-95 pointerdevice:group-active:scale-95" />
+    </button>
+  );
+}

--- a/src/pages/Root/archive/page.tsx
+++ b/src/pages/Root/archive/page.tsx
@@ -1,10 +1,11 @@
 import testImage from '@Assets/test_fashion_image.jpg';
+import { ShowNotificationButton } from '@Components/ShowNotificationButton';
 import { useHeader } from '@Hooks/useHeader';
 import { cn, isBetweenDate } from '@Utils/index';
 import { addMonths, format, getDaysInMonth, getWeeksInMonth, isSameMonth, isSameYear, startOfDay, subMonths } from 'date-fns';
 import { AnimatePresence, motion, Variants } from 'framer-motion';
 import { useRef, useState, useTransition } from 'react';
-import { MdChevronLeft, MdChevronRight, MdOutlineNotificationsNone, MdSearch } from 'react-icons/md';
+import { MdChevronLeft, MdChevronRight, MdSearch } from 'react-icons/md';
 import './dateStyle.css';
 
 const MIN_DATE = new Date('2024-01-01');
@@ -50,7 +51,7 @@ export default function Page() {
 
   return (
     <div className="flex h-full flex-col">
-      <menu className="sticky top-0 z-10 flex flex-row bg-white px-5">
+      <menu className="sticky top-0 flex flex-row bg-white px-5">
         <li className="flex-1">
           <button className="relative h-full w-full py-3" onClick={() => switchToTab(0)} disabled={isTransitionInProgress}>
             <span className={cn('text-h6 font-semibold text-gray-500 transition-colors', { ['text-current']: isFAPTab })}>FA:P 아카이브</span>
@@ -87,14 +88,6 @@ function SearchButton() {
   return (
     <button className="group cursor-pointer rounded-lg p-2 touchdevice:active:bg-gray-100 pointerdevice:hover:bg-gray-100">
       <MdSearch className="size-6 transition-transform touchdevice:group-active:scale-95 pointerdevice:group-active:scale-95" />
-    </button>
-  );
-}
-
-function ShowNotificationButton() {
-  return (
-    <button className="group cursor-pointer rounded-lg p-2 touchdevice:active:bg-gray-100 pointerdevice:hover:bg-gray-100">
-      <MdOutlineNotificationsNone className="size-6 transition-transform touchdevice:group-active:scale-95 pointerdevice:group-active:scale-95" />
     </button>
   );
 }

--- a/src/pages/Root/mypage/page.tsx
+++ b/src/pages/Root/mypage/page.tsx
@@ -1,8 +1,9 @@
 import testImage from '@Assets/test_fashion_image.jpg';
+import { ShowNotificationButton } from '@Components/ShowNotificationButton';
 import { useConfirm, useModalActions } from '@Hooks/modal';
 import { useHeader } from '@Hooks/useHeader';
 import { IconType } from 'react-icons/lib';
-import { MdBook, MdBookmark, MdHowToVote, MdOutlineNotificationsNone, MdPerson } from 'react-icons/md';
+import { MdBook, MdBookmark, MdHowToVote, MdPerson } from 'react-icons/md';
 import { useNavigate } from 'react-router-dom';
 import AccountSetting from './components/AccountSetting';
 
@@ -83,14 +84,6 @@ export default function Page() {
         <LogoutButton />
       </div>
     </div>
-  );
-}
-
-function ShowNotificationButton() {
-  return (
-    <button className="group relative cursor-pointer rounded-lg p-2 touchdevice:active:bg-gray-100 pointerdevice:hover:bg-gray-100">
-      <MdOutlineNotificationsNone className="size-6 transition-transform touchdevice:group-active:scale-95 pointerdevice:group-active:scale-95" />
-    </button>
   );
 }
 

--- a/src/pages/Root/subscribe/page.tsx
+++ b/src/pages/Root/subscribe/page.tsx
@@ -1,5 +1,6 @@
 import { OUTFIT_CATEGORY_LIST, OUTFIT_STYLE_LIST } from '@/constants';
 import testImage from '@Assets/test_fashion_image.jpg';
+import { ShowNotificationButton } from '@Components/ShowNotificationButton';
 import { useModalActions } from '@Hooks/modal';
 import { useToastActions } from '@Hooks/toast';
 import { useHeader } from '@Hooks/useHeader';
@@ -7,7 +8,7 @@ import { cn } from '@Utils/index';
 import { format } from 'date-fns';
 import { ko } from 'date-fns/locale';
 import { motion } from 'framer-motion';
-import { MdBookmark, MdChevronRight, MdOutlineNotificationsNone, MdReport } from 'react-icons/md';
+import { MdBookmark, MdChevronRight, MdReport } from 'react-icons/md';
 import { ReportBottomSheet, ReportResult } from '../voteFAP/components/ReportBottomSheet';
 
 type SubscribeBadgeType = {
@@ -65,7 +66,7 @@ export default function Page() {
           </ul>
         </div>
 
-        <button className="bg-fade-gradient absolute right-5 top-1/2 -translate-y-1/2 px-2 py-4">
+        <button className="absolute right-5 top-1/2 -translate-y-1/2 bg-fade-gradient px-2 py-4">
           <MdChevronRight className="size-6" />
         </button>
       </div>
@@ -78,14 +79,6 @@ export default function Page() {
         <FeedCard />
       </div>
     </div>
-  );
-}
-
-function ShowNotificationButton() {
-  return (
-    <button className="group relative cursor-pointer rounded-lg p-2 touchdevice:active:bg-gray-100 pointerdevice:hover:bg-gray-100">
-      <MdOutlineNotificationsNone className="size-6 transition-transform touchdevice:group-active:scale-95 pointerdevice:group-active:scale-95" />
-    </button>
   );
 }
 

--- a/src/pages/Root/voteFAP/page.tsx
+++ b/src/pages/Root/voteFAP/page.tsx
@@ -1,10 +1,10 @@
+import { ShowNotificationButton } from '@Components/ShowNotificationButton';
 import { useModalActions } from '@Hooks/modal';
 import { useHeader } from '@Hooks/useHeader';
 import { FlexibleLayout } from '@Layouts/FlexibleLayout';
 import { useVotingStore } from '@Stores/vote';
 import { AnimatePresence, motion } from 'framer-motion';
-import { useState } from 'react';
-import { MdInfoOutline, MdOutlineNotificationsNone } from 'react-icons/md';
+import { MdInfoOutline } from 'react-icons/md';
 import { VoteController } from './components/VoteController';
 import { VotePolicyBottomSheet } from './components/VotePolicyBottomSheet';
 
@@ -59,24 +59,6 @@ function ShowVotePolicyButton() {
   return (
     <button className="group cursor-pointer rounded-lg p-2 touchdevice:active:bg-gray-100 pointerdevice:hover:bg-gray-100" onClick={showVotePolicyModal}>
       <MdInfoOutline className="size-6 transition-transform touchdevice:group-active:scale-95 pointerdevice:group-active:scale-95" />
-    </button>
-  );
-}
-
-function ShowNotificationButton() {
-  const [isOpened, setIsOpened] = useState(false);
-
-  return (
-    <button
-      className="group relative cursor-pointer rounded-lg p-2 touchdevice:active:bg-gray-100 pointerdevice:hover:bg-gray-100"
-      onClick={() => setIsOpened(!isOpened)}>
-      <MdOutlineNotificationsNone className="size-6 transition-transform touchdevice:group-active:scale-95 pointerdevice:group-active:scale-95" />
-
-      {isOpened && (
-        <div className="absolute right-4 top-full flex min-w-max rounded border bg-white p-5">
-          <p>흐으음..</p>
-        </div>
-      )}
     </button>
   );
 }

--- a/src/types/notification.ts
+++ b/src/types/notification.ts
@@ -1,0 +1,65 @@
+import { IconType } from 'react-icons/lib';
+
+export type TNotificationType = 'FEED_REPORTED' | 'FEED_DELETED' | 'FAP_SELECTED' | 'FAP_DELETED';
+
+interface TNotificationBase {
+  type: TNotificationType;
+  isRead: boolean;
+  createdAt: Date;
+}
+
+interface TNotificationFeedReported extends TNotificationBase {
+  type: 'FEED_REPORTED';
+  feedId: number;
+  reportCount: number;
+}
+
+interface TNotificationFeedDeleted extends TNotificationBase {
+  type: 'FEED_DELETED';
+}
+
+interface TNotificationFAPSelected extends TNotificationBase {
+  type: 'FAP_SELECTED';
+  selectedDate: string;
+}
+
+interface TNotificationFAPDeleted extends TNotificationBase {
+  type: 'FAP_DELETED';
+  deletedFAPCount: number;
+}
+
+export type TNotification = TNotificationFeedReported | TNotificationFeedDeleted | TNotificationFAPSelected | TNotificationFAPDeleted;
+
+export function isFeedReportedNotification(notification: TNotification): notification is TNotificationFeedReported {
+  return notification.type === 'FEED_REPORTED';
+}
+
+export function isFeedDeletedNotification(notification: TNotification): notification is TNotificationFeedDeleted {
+  return notification.type === 'FEED_DELETED';
+}
+
+export function isFAPSelectedNotification(notification: TNotification): notification is TNotificationFAPSelected {
+  return notification.type === 'FAP_SELECTED';
+}
+
+export function isFAPDeletedNotification(notification: TNotification): notification is TNotificationFAPDeleted {
+  return notification.type === 'FAP_DELETED';
+}
+
+export type NotificationData<T extends TNotificationType> = {
+  IconComponent: IconType;
+  iconColor: string;
+  getMessage: T extends 'FEED_REPORTED'
+    ? (count: number) => string
+    : T extends 'FEED_DELETED'
+      ? () => string
+      : T extends 'FAP_SELECTED'
+        ? (date: string) => string
+        : T extends 'FAP_DELETED'
+          ? (count: number) => string
+          : never;
+};
+
+export type NotificationDataMap = {
+  [K in TNotificationType]: NotificationData<K>;
+};

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -239,3 +239,20 @@ export function sameOrBefore(d1 = new Date(), d2 = new Date()) {
 export function sameOrAfter(d1 = new Date(), d2 = new Date()) {
   return isSameYear(d1, d2) && isSameMonth(d1, d2) ? true : isAfter(d1, d2) ? true : false;
 }
+
+export function getRelativeTimeLabel(date: Date) {
+  const rtf = new Intl.RelativeTimeFormat('ko', { numeric: 'auto' });
+  const now = new Date();
+  const diffTime = date.getTime() - now.getTime();
+  const diffDays = Math.ceil(diffTime / (1000 * 60 * 60 * 24));
+  const diffWeeks = Math.ceil(diffDays / 7);
+  const diffMonths = Math.ceil(diffDays / 30);
+
+  if (Math.abs(diffDays) < 7) {
+    return rtf.format(diffDays, 'day');
+  } else if (Math.abs(diffWeeks) < 4) {
+    return rtf.format(diffWeeks, 'week');
+  } else {
+    return rtf.format(diffMonths, 'month');
+  }
+}


### PR DESCRIPTION
### 관련된 이슈 번호를 기입해주세요.
> `close #이슈번호` 와 같은 형식으로 작성해주세요.

- close #111 

### 어떤 부분이 변경됐나요?
> 어떤 부분을 변경했는지, 무슨 이유로 코드를 변경했는지 설명해주세요.

**알림 화면을 작성했어요.**
- 알림 버튼을 누르면 Full Screen Dialog이 노출됩니다.

| 알림 화면 |
| --- |
| ![image](https://github.com/user-attachments/assets/2af59701-cf46-4e6d-a6df-0bcbe87daaae) |

**알림에 대한 타입을 작성했어요.**
- 생각보다.. 어려웠습니다. 그러면서 문득 떠오른 기억: 예전에도 알림으로 삽질했었던 것 같은데...
- 알림 종류에 따라 interface를 작성했고, 지칭하는 type을 만들었습니다.
- 해당 알림이 어떤 종류인지에 대한 타입 가드 함수를 만들었습니다.
- 의외로 getMessage()에서 애를 먹었는데.. 일단 그냥 extends로 해결봤습니다.

### 추가 정보 (선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.

- 해당 없음
