### PR TITLE
변경된 Auth API 반영 & 투표 API 연동 & 구독 API 연동 & 북마크 API 연동

### DIFF
--- a/src/__mock__/handlers.ts
+++ b/src/__mock__/handlers.ts
@@ -1,3 +1,4 @@
+import { UserDetail } from '@Types/model';
 import { ServiceErrorResponse } from '@Types/serviceError';
 import { HttpStatusCode } from 'axios';
 import { addDays } from 'date-fns';
@@ -31,11 +32,11 @@ const testFahsionImages = [
 const NETWORK_DELAY = 1000;
 const BASE_URL = import.meta.env.VITE_API_BASE_URL;
 
-const userData = {
-  id: 'c7b3d8e0-5e0b-4b0f-8b3a-3b9f4b3d3b3d',
-  email: 'test_email@fadeapp.site',
-  // accountId: '',
-  accountId: 'test_accountId',
+const userData: UserDetail = {
+  id: 0,
+  accountId: 'fade_1234',
+  genderType: 'MALE',
+  profileImageURL: testFashionImage1,
 };
 
 export const handlers = [

--- a/src/__mock__/handlers.ts
+++ b/src/__mock__/handlers.ts
@@ -3,7 +3,7 @@ import { ServiceErrorResponse } from '@Types/serviceError';
 import { HttpStatusCode } from 'axios';
 import { addDays } from 'date-fns';
 import { HttpResponse, delay, http } from 'msw';
-import { createAccessToken, createRefreshToken } from './utils';
+import { createAccessToken, createRefreshToken, generateTVoteCandidateDummyData } from './utils';
 
 import testFashionImage1 from '@Assets/test_fashion_image.jpg';
 import testFashionImage10 from '@Assets/test_fashion_image_10.jpg';
@@ -223,46 +223,34 @@ export const handlers = [
   http.get(`${BASE_URL}/vote/candidates`, async () => {
     await delay(NETWORK_DELAY);
 
-    const feeds = testFahsionImages.map(
-      (image) =>
-        ({
-          id: Math.floor(Math.random() * 100),
-          memberId: Math.floor(Math.random() * 100),
-          imageURL: image,
-          styleIds: [0, 1, 2, 3, 4],
-          outfits: [
-            {
-              id: 0,
-              brandName: '나이키',
-              categoryId: 0,
-              details: '공홈',
-            },
-            {
-              id: 1,
-              brandName: '나이키1',
-              categoryId: 1,
-              details: '공홈1',
-            },
-            {
-              id: 2,
-              brandName: '나이키2',
-              categoryId: 2,
-              details: '공홈2',
-            },
-            {
-              id: 3,
-              brandName: '나이키3',
-              categoryId: 3,
-              details: '공홈3',
-            },
-          ],
-        }) as TFeed
-    );
-
-    return HttpResponse.json({ feeds }, { status: HttpStatusCode.Ok });
+    return HttpResponse.json({ feeds: generateTVoteCandidateDummyData(10) }, { status: HttpStatusCode.Ok });
   }),
 
   http.post(`${BASE_URL}/vote/candidates`, async () => {
+    await delay(NETWORK_DELAY);
+
+    return new HttpResponse('', { status: HttpStatusCode.Ok });
+  }),
+
+  http.post(`${BASE_URL}/subscribe/:toMemberId`, async () => {
+    await delay(NETWORK_DELAY);
+
+    return new HttpResponse('', { status: HttpStatusCode.Ok });
+  }),
+
+  http.delete(`${BASE_URL}/subscribe/:toMemberId`, async () => {
+    await delay(NETWORK_DELAY);
+
+    return new HttpResponse('', { status: HttpStatusCode.Ok });
+  }),
+
+  http.post(`${BASE_URL}/bookmark/:feedId`, async () => {
+    await delay(NETWORK_DELAY);
+
+    return new HttpResponse('', { status: HttpStatusCode.Ok });
+  }),
+
+  http.delete(`${BASE_URL}/bookmark/:feedId`, async () => {
     await delay(NETWORK_DELAY);
 
     return new HttpResponse('', { status: HttpStatusCode.Ok });

--- a/src/__mock__/handlers.ts
+++ b/src/__mock__/handlers.ts
@@ -43,7 +43,7 @@ export const handlers = [
    * MSW는 fetch 정책 상 Header에 Set-Cookie를 지정해주는 대신
    * document.cookie로 지정해주기 때문에, HttpOnly 속성을 넣으면 안 된다(😇)
    */
-  http.post(`${BASE_URL}/auth/refresh`, async ({ cookies }) => {
+  http.post(`${BASE_URL}/auth/token`, async ({ cookies }) => {
     const { refreshToken } = cookies;
 
     await delay(NETWORK_DELAY);

--- a/src/__mock__/handlers.ts
+++ b/src/__mock__/handlers.ts
@@ -1,4 +1,4 @@
-import { UserDetail } from '@Types/model';
+import { TFeed, UserDetail } from '@Types/model';
 import { ServiceErrorResponse } from '@Types/serviceError';
 import { HttpStatusCode } from 'axios';
 import { addDays } from 'date-fns';
@@ -223,13 +223,43 @@ export const handlers = [
   http.get(`${BASE_URL}/vote/candidates`, async () => {
     await delay(NETWORK_DELAY);
 
-    const voteCandidates = testFahsionImages.map((image) => ({
-      feedId: Math.floor(Math.random() * 100),
-      userId: Math.floor(Math.random() * 100),
-      imageURL: image,
-    }));
+    const feeds = testFahsionImages.map(
+      (image) =>
+        ({
+          id: Math.floor(Math.random() * 100),
+          memberId: Math.floor(Math.random() * 100),
+          imageURL: image,
+          styleIds: [0, 1, 2, 3, 4],
+          outfits: [
+            {
+              id: 0,
+              brandName: '나이키',
+              categoryId: 0,
+              details: '공홈',
+            },
+            {
+              id: 1,
+              brandName: '나이키1',
+              categoryId: 1,
+              details: '공홈1',
+            },
+            {
+              id: 2,
+              brandName: '나이키2',
+              categoryId: 2,
+              details: '공홈2',
+            },
+            {
+              id: 3,
+              brandName: '나이키3',
+              categoryId: 3,
+              details: '공홈3',
+            },
+          ],
+        }) as TFeed
+    );
 
-    return HttpResponse.json({ voteCandidates }, { status: HttpStatusCode.Ok });
+    return HttpResponse.json({ feeds }, { status: HttpStatusCode.Ok });
   }),
 
   http.post(`${BASE_URL}/vote/candidates`, async () => {

--- a/src/__mock__/utils.ts
+++ b/src/__mock__/utils.ts
@@ -1,6 +1,7 @@
+import { UserDetail } from '@Types/model';
 import { addDays, addHours } from 'date-fns';
 
-function encodeJWT(payload: Record<string, string>, secret: string, exp: Date) {
+function encodeJWT(payload: UserDetail, secret: string, exp: Date) {
   const header = {
     alg: 'HS256',
     typ: 'JWT',
@@ -14,7 +15,7 @@ function encodeJWT(payload: Record<string, string>, secret: string, exp: Date) {
   return `${encodedHeader}.${encodedPayload}.${signature}`;
 }
 
-const createJWT = (userData: Record<string, string>, expiresIn: Date) => encodeJWT(userData, 'JWT_SECRET', expiresIn);
+const createJWT = (userData: UserDetail, expiresIn: Date) => encodeJWT(userData, 'JWT_SECRET', expiresIn);
 
-export const createAccessToken = (userData: Record<string, string>) => createJWT(userData, addHours(new Date(), 1));
-export const createRefreshToken = (userData: Record<string, string>) => createJWT(userData, addDays(new Date(), 14));
+export const createAccessToken = (userData: UserDetail) => createJWT(userData, addHours(new Date(), 1));
+export const createRefreshToken = (userData: UserDetail) => createJWT(userData, addDays(new Date(), 14));

--- a/src/__mock__/utils.ts
+++ b/src/__mock__/utils.ts
@@ -1,5 +1,29 @@
-import { UserDetail } from '@Types/model';
+import { TOutfitItem, TVoteCandidate, UserDetail } from '@Types/model';
 import { addDays, addHours } from 'date-fns';
+
+import testFashionImage1 from '@Assets/test_fashion_image.jpg';
+import testFashionImage10 from '@Assets/test_fashion_image_10.jpg';
+import testFashionImage2 from '@Assets/test_fashion_image_2.jpg';
+import testFashionImage3 from '@Assets/test_fashion_image_3.jpg';
+import testFashionImage4 from '@Assets/test_fashion_image_4.jpg';
+import testFashionImage5 from '@Assets/test_fashion_image_5.webp';
+import testFashionImage6 from '@Assets/test_fashion_image_6.jpg';
+import testFashionImage7 from '@Assets/test_fashion_image_7.jpg';
+import testFashionImage8 from '@Assets/test_fashion_image_8.jpg';
+import testFashionImage9 from '@Assets/test_fashion_image_9.jpg';
+
+const testFahsionImages = [
+  testFashionImage1,
+  testFashionImage2,
+  testFashionImage3,
+  testFashionImage4,
+  testFashionImage5,
+  testFashionImage6,
+  testFashionImage7,
+  testFashionImage8,
+  testFashionImage9,
+  testFashionImage10,
+];
 
 function encodeJWT(payload: UserDetail, secret: string, exp: Date) {
   const header = {
@@ -19,3 +43,56 @@ const createJWT = (userData: UserDetail, expiresIn: Date) => encodeJWT(userData,
 
 export const createAccessToken = (userData: UserDetail) => createJWT(userData, addHours(new Date(), 1));
 export const createRefreshToken = (userData: UserDetail) => createJWT(userData, addDays(new Date(), 14));
+
+function getRandomNumber(min: number, max: number): number {
+  return Math.floor(Math.random() * (max - min + 1)) + min;
+}
+
+function getRandomBoolean(): boolean {
+  return Math.random() < 0.5;
+}
+
+function getRandomBrandName(): string {
+  const brands = ['Nike', 'Adidas', 'Puma', 'Reebok', 'Uniqlo', 'Gucci', 'Prada'];
+  return brands[getRandomNumber(0, brands.length - 1)];
+}
+
+function getRandomString(length: number): string {
+  const chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+  let result = '';
+  for (let i = 0; i < length; i++) {
+    result += chars.charAt(getRandomNumber(0, chars.length - 1));
+  }
+  return result;
+}
+
+function createRandomOutfitItem(index: number): TOutfitItem {
+  return {
+    id: index,
+    brandName: getRandomBrandName(),
+    details: getRandomString(15),
+    categoryId: getRandomNumber(0, 6),
+  };
+}
+
+function createRandomTVoteCandidate(): TVoteCandidate {
+  const styleIdsLength = getRandomNumber(1, 6);
+  const outfitsLength = getRandomNumber(1, 5);
+
+  const styleIds = Array.from({ length: styleIdsLength }, () => getRandomNumber(0, 10));
+  const outfits = Array.from({ length: outfitsLength }, (_, index) => createRandomOutfitItem(index + 1));
+
+  return {
+    feedId: getRandomNumber(0, 99),
+    memberId: getRandomNumber(1, 1000),
+    imageURL: testFahsionImages[getRandomNumber(0, testFahsionImages.length - 1)],
+    styleIds,
+    outfits,
+    isSubscribed: getRandomBoolean(),
+    isBookmarked: getRandomBoolean(),
+  };
+}
+
+export function generateTVoteCandidateDummyData(size: number): TVoteCandidate[] {
+  return Array.from({ length: size }, () => createRandomTVoteCandidate());
+}

--- a/src/components/LockUI.tsx
+++ b/src/components/LockUI.tsx
@@ -1,0 +1,15 @@
+import { MdLock } from 'react-icons/md';
+
+export default function LockUI() {
+  return (
+    <div className="grid min-h-screen place-content-center gap-3 bg-gradient-to-br from-white to-purple-50">
+      <div className="mx-auto">
+        <MdLock className="size-24 text-purple-500" />
+      </div>
+      <div className="space-y-0.5 px-2">
+        <p className="text-center text-h2 font-medium">오늘의 투표를 완료해주세요!</p>
+        <p className="text-center text-h6 font-light leading-tight text-gray-900">하루 최소 1사이클(10회) 이상 FA:P 투표를 완료해야 다른 기능을 이용할 수 있어요.</p>
+      </div>
+    </div>
+  );
+}

--- a/src/components/ReportButton.tsx
+++ b/src/components/ReportButton.tsx
@@ -30,6 +30,7 @@ export function ReportButton({ feedId, onReportEnd }: ReportButtonProps) {
       { feedId },
       {
         onSuccess() {
+          showToast({ type: 'basic', title: `${feedId}번 피드를 신고하였습니다.` });
           onReportEnd && onReportEnd(reportResult);
         },
         onError() {

--- a/src/components/SubscribeButton.tsx
+++ b/src/components/SubscribeButton.tsx
@@ -1,7 +1,9 @@
 import { useMutation } from '@tanstack/react-query';
 import { cn } from '@Utils/index';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Button } from './ui/button';
+import { requestSubscribeMember } from '@Services/member';
+import { useToastActions } from '@Hooks/toast';
 
 type SubscribeButtonSize = 'default' | 'lg';
 
@@ -16,44 +18,29 @@ type SubscribeButtonProps = TSubscribeButton;
 
 export function SubscribeButton({ size = 'default', userId, initialSubscribedStatus, onToggle }: SubscribeButtonProps) {
   const [isSubscribed, setIsSubscribed] = useState(initialSubscribedStatus);
+  const { showToast } = useToastActions();
 
-  const subscribeMutation = useMutation({
-    mutationKey: ['subscribe'],
-    mutationFn: ({ userId }: { userId: number }) => new Promise((resolve) => resolve(userId)),
+  const { mutate: subscribeMember, isPending } = useMutation({
+    mutationKey: ['subscribeMember'],
+    mutationFn: requestSubscribeMember,
   });
 
-  const unsubscribeButton = useMutation({
-    mutationKey: ['unsubscribe'],
-    mutationFn: ({ userId }: { userId: number }) => new Promise((resolve) => resolve(userId)),
-  });
-
-  const isPending = subscribeMutation.isPending || unsubscribeButton.isPending;
+  useEffect(() => {
+    setIsSubscribed(initialSubscribedStatus);
+  }, [initialSubscribedStatus]);
 
   const handleClick = () => {
     setIsSubscribed((prev) => !prev);
 
-    if (!isSubscribed) {
-      return subscribeMutation.mutate(
-        { userId },
-        {
-          onSuccess() {
-            onToggle(!initialSubscribedStatus);
-          },
-          onError() {
-            setIsSubscribed((prev) => !prev);
-          },
-        }
-      );
-    }
-
-    unsubscribeButton.mutate(
-      { userId },
+    subscribeMember(
+      { toMemberId: userId, wouldSubscribe: !initialSubscribedStatus },
       {
         onSuccess() {
           onToggle(!initialSubscribedStatus);
         },
         onError() {
           setIsSubscribed((prev) => !prev);
+          showToast({ type: 'error', title: '구독에 실패했어요.' });
         },
       }
     );

--- a/src/components/Tooltip.tsx
+++ b/src/components/Tooltip.tsx
@@ -1,0 +1,8 @@
+export default function Tooltip() {
+  return (
+    <div className="absolute">
+      <div className="relative break-words rounded-2xl bg-purple-500 px-6 py-2 text-center text-white">FA:P 투표하러 가기!</div>
+      <div className="mx-auto h-0 w-0 border-l-8 border-r-8 border-t-8 border-l-transparent border-r-transparent border-t-purple-500"></div>
+    </div>
+  );
+}

--- a/src/components/forms/account/AccountInitializeForm.tsx
+++ b/src/components/forms/account/AccountInitializeForm.tsx
@@ -35,7 +35,7 @@ export function AccountInitializeForm({ accessToken, onSubmited }: AccountInitia
     resolver: zodResolver(accountInitializeSchema),
     defaultValues: {
       accountId: '',
-      gender: 'men',
+      gender: 'MALE',
     },
     mode: 'onChange',
   });

--- a/src/components/forms/account/_accountSchema.ts
+++ b/src/components/forms/account/_accountSchema.ts
@@ -5,7 +5,7 @@ const accountIdRegExp = new RegExp(/^[a-zA-Z0-9._]{4,15}$/);
 export const accountSchema = z.object({
   profileImageId: z.number(),
   accountId: z.string().regex(accountIdRegExp, '사용할 수 없는 ID입니다.'),
-  gender: z.enum(['men', 'women']),
+  gender: z.enum(['MALE', 'FEMALE']),
 });
 
 export const accountInitializeSchema = accountSchema.pick({

--- a/src/components/forms/account/fields/GenderField.tsx
+++ b/src/components/forms/account/fields/GenderField.tsx
@@ -21,12 +21,12 @@ export function GenderField({ control }: GenderFieldProps) {
           <FormControl>
             <RadioGroup.Root defaultValue="men" className="flex w-full flex-row gap-5" value={field.value} onValueChange={field.onChange}>
               <RadioGroup.Item
-                value="men"
+                value="MALE"
                 className="flex flex-1 items-center justify-center rounded-lg bg-gray-200 py-3 text-black transition-colors data-[state=checked]:bg-violet-500 data-[state=checked]:text-white">
                 <p>남자</p>
               </RadioGroup.Item>
               <RadioGroup.Item
-                value="women"
+                value="FEMALE"
                 className="flex flex-1 items-center justify-center rounded-lg bg-gray-200 py-3 text-black transition-colors data-[state=checked]:bg-violet-500 data-[state=checked]:text-white">
                 <p>여자</p>
               </RadioGroup.Item>

--- a/src/hooks/auth.ts
+++ b/src/hooks/auth.ts
@@ -19,7 +19,8 @@ export const useAuthActions = () => {
 
   const signIn = useCallback(
     ({ accessToken, csrfToken }: AuthTokens) => {
-      setTokens({ accessToken, csrfToken });
+      /** NOTE: CSRF Token 보류 */
+      setTokens({ accessToken, csrfToken: csrfToken || '' });
       setAuthFromToken({ accessToken });
     },
     [setTokens, setAuthFromToken]

--- a/src/hooks/auth.ts
+++ b/src/hooks/auth.ts
@@ -1,5 +1,5 @@
 import { useAuthStore } from '@Stores/auth';
-import { AuthTokens } from '@Types/User';
+import { AuthTokens } from '@Types/model';
 import { useCallback, useMemo } from 'react';
 
 export const useUser = () => useAuthStore((state) => state.user);
@@ -8,8 +8,7 @@ export const useCsrfToken = () => useAuthStore((state) => state.csrfToken);
 
 export const useIsAuthenticated = () => {
   const user = useUser();
-
-  return useMemo(() => !!user, [user]);
+  return useMemo(() => user.id !== -1, [user]);
 };
 
 export const useAuthActions = () => {

--- a/src/pages/Root/voteFAP/components/VotingView.tsx
+++ b/src/pages/Root/voteFAP/components/VotingView.tsx
@@ -3,8 +3,9 @@ import { SubscribeButton } from '@Components/SubscribeButton';
 import { Image } from '@Components/ui/image';
 import { useToastActions } from '@Hooks/toast';
 import { requestGetVoteCandidates, requestSendVoteResult } from '@Services/vote';
-import { SwipeDirection, useVotingStore, VoteCandidateCardType } from '@Stores/vote';
+import { SwipeDirection, useVotingStore } from '@Stores/vote';
 import { useMutation, useQuery } from '@tanstack/react-query';
+import { TVoteCandidateCard } from '@Types/model';
 import { ServiceErrorResponse } from '@Types/serviceError';
 import { cn, generateAnonName, prefetchImages } from '@Utils/index';
 import { isAxiosError } from 'axios';
@@ -80,9 +81,9 @@ export function VotingView({ onSubmitDone }: { onSubmitDone: () => void }) {
     prefetchImages([swipeFadeInImage, swipeFadeOutImage, voteFadeInImage, voteFadeOutImage]);
 
     /** viewCards 설정 */
-    const { voteCandidates } = response.data;
+    const { voteCandidates } = response;
 
-    const voteCandidateCards: VoteCandidateCardType[] = voteCandidates.map((voteCandidate) => ({
+    const voteCandidateCards: TVoteCandidateCard[] = voteCandidates.map((voteCandidate) => ({
       ...voteCandidate,
       anonName: generateAnonName(),
     }));
@@ -272,7 +273,7 @@ function VoteCandidateCards() {
   );
 }
 
-type VoteCandidateCardProps = { isCurrentCard: boolean } & VoteCandidateCardType;
+type VoteCandidateCardProps = { isCurrentCard: boolean } & TVoteCandidateCard;
 
 function VoteCandidateCard({ feedId, imageURL, isCurrentCard }: VoteCandidateCardProps) {
   const handleSelect = useVotingStore((state) => state.handleSelect);

--- a/src/pages/Root/voteFAP/components/VotingView.tsx
+++ b/src/pages/Root/voteFAP/components/VotingView.tsx
@@ -1,7 +1,9 @@
 import { ReportButton } from '@Components/ReportButton';
 import { SubscribeButton } from '@Components/SubscribeButton';
+import { Button } from '@Components/ui/button';
 import { Image } from '@Components/ui/image';
 import { useToastActions } from '@Hooks/toast';
+import { requestBookmarkFeed } from '@Services/feed';
 import { requestGetVoteCandidates, requestSendVoteResult } from '@Services/vote';
 import { SwipeDirection, useVotingStore } from '@Stores/vote';
 import { useMutation, useQuery } from '@tanstack/react-query';
@@ -300,15 +302,8 @@ function VoteCandidateCard({ feedId, imageURL, isCurrentCard }: VoteCandidateCar
 
   return (
     <motion.div
-      style={{
-        x: computedX,
-        rotate: computedRotate,
-        backgroundImage: `url('${imageURL}')`,
-        backgroundSize: 'contain',
-        backgroundRepeat: 'no-repeat',
-        backgroundPosition: 'center',
-      }}
-      className="relative flex-1 rounded-lg bg-gray-200 shadow-bento">
+      style={{ x: computedX, rotate: computedRotate, backgroundImage: `url('${imageURL}')` }}
+      className="relative flex-1 rounded-lg bg-gray-200 bg-contain bg-center bg-no-repeat shadow-bento">
       {isCurrentCard && (
         <motion.div
           initial={{ opacity: 0 }}
@@ -387,13 +382,14 @@ function DragController({ x, onDragStart, onDragEnd, onDragOffBoundary }: DragCo
 
 function UserDetailCard() {
   const anonName = useVotingStore(({ viewCards }) => viewCards.at(-1)?.anonName || '');
+  const isSubscribed = useVotingStore(({ viewCards }) => viewCards.at(-1)?.isSubscribed || false);
+  const memberId = useVotingStore(({ viewCards }) => viewCards.at(-1)?.memberId || -1);
 
   return (
     <div className="flex flex-row items-center justify-center gap-3 rounded-lg bg-white px-3 py-2 shadow-bento">
       <RandomAvatar />
       <AnimatedUsername name={anonName} />
-      {/* <button className="rounded-lg border border-gray-200 px-4 py-1">구독</button> */}
-      <SubscribeButton initialSubscribedStatus={false} userId={0} onToggle={(value) => console.log(value)} />
+      <SubscribeButton initialSubscribedStatus={isSubscribed} userId={memberId} onToggle={(value) => console.log(value)} />
     </div>
   );
 }
@@ -432,6 +428,8 @@ function AnimatedUsername({ name }: { name: string }) {
 
 function VotingTools() {
   const handleSelect = useVotingStore((state) => state.handleSelect);
+  const feedId = useVotingStore(({ viewCards }) => viewCards.at(-1)?.feedId || -1);
+  const isBookmarked = useVotingStore(({ viewCards }) => viewCards.at(-1)?.isBookmarked || false);
 
   return (
     <div className="flex w-full flex-col gap-3">
@@ -440,7 +438,7 @@ function VotingTools() {
       <div className="flex flex-row gap-3">
         <VoteButton type="fadeOut" onClick={() => handleSelect('left')} />
         <VoteButton type="fadeIn" onClick={() => handleSelect('right')} />
-        <BookmarkButton />
+        <BookmarkButton feedId={feedId} defaultBookmarkStatus={isBookmarked} />
       </div>
     </div>
   );
@@ -470,10 +468,57 @@ function VoteButton({ type, onClick }: VoteButtonProps) {
   );
 }
 
-function BookmarkButton() {
+interface TBookmarkButton {
+  feedId: number;
+  defaultBookmarkStatus: boolean;
+}
+
+type BookmarkButtonProps = TBookmarkButton;
+
+function BookmarkButton({ feedId, defaultBookmarkStatus }: BookmarkButtonProps) {
+  const [isBookmarked, setIsBookmarked] = useState(defaultBookmarkStatus);
+  const { showToast } = useToastActions();
+
+  const { mutate: bookmarkFeed, isPending } = useMutation({
+    mutationKey: ['bookmarkFeed'],
+    mutationFn: requestBookmarkFeed,
+  });
+
+  useEffect(() => {
+    setIsBookmarked(defaultBookmarkStatus);
+  }, [defaultBookmarkStatus]);
+
+  const handleClick = () => {
+    setIsBookmarked((prev) => !prev);
+
+    bookmarkFeed(
+      {
+        feedId,
+        wouldBookmark: !defaultBookmarkStatus,
+      },
+      {
+        onError() {
+          setIsBookmarked((prev) => !prev);
+          showToast({ type: 'error', title: '북마크에 실패했어요.' });
+        },
+      }
+    );
+  };
+
   return (
-    <button className="rounded-lg bg-white p-3 shadow-bento">
-      <MdBookmark className="size-6 text-gray-600" />
-    </button>
+    <Button
+      variants="white"
+      interactive="onlyScale"
+      className={cn('shadow-bento', {
+        ['bg-purple-500']: isBookmarked,
+      })}
+      disabled={isPending}
+      onClick={handleClick}>
+      <MdBookmark
+        className={cn('size-6 text-gray-600 transition-colors', {
+          ['text-white']: isBookmarked,
+        })}
+      />
+    </Button>
   );
 }

--- a/src/services/auth.ts
+++ b/src/services/auth.ts
@@ -16,11 +16,11 @@ type RefreshTokenResponse = AuthTokens;
 
 /** RefreshToken으로 AccessToken을 요청 */
 export async function requestRefreshToken() {
-  return await axios.post<RefreshTokenResponse>('/auth/refresh');
+  return await axios.post<RefreshTokenResponse>('/auth/token');
 }
 
 export const enum SignUpType {
-  KAKAO = 'kakao',
+  KAKAO = 'KAKAO',
 }
 
 type SignUpPayload = { signUpType: SignUpType; accessToken: string; accountId: string; gender: string };
@@ -28,7 +28,11 @@ type SignUpResponse = AuthTokens;
 
 /** 회원가입 요청 */
 export async function requestSignUp(payload: SignUpPayload) {
-  return await axios.post<SignUpResponse>(`/auth/social-login/KAKAO/signup`, payload);
+  return await axios.post<SignUpResponse>(`/auth/social-login/${payload.signUpType}/signup`, {
+    socialAccessToken: payload.accessToken,
+    username: payload.accountId,
+    genderType: payload.gender,
+  });
 }
 
 type SignInWithCodePayload = { authorizationCode: string };

--- a/src/services/feed.ts
+++ b/src/services/feed.ts
@@ -12,3 +12,14 @@ type CreateFeedResponse = { feedId: number };
 export async function requestCreateFeed(payload: CreateFeedPayload) {
   return await axios.post<CreateFeedResponse>(`/feeds`, payload);
 }
+
+type BookmarkFeedPayload = { feedId: number; wouldBookmark: boolean };
+type BookmarkFeedResponse = null;
+
+export async function requestBookmarkFeed({ feedId, wouldBookmark }: BookmarkFeedPayload) {
+  if (wouldBookmark) {
+    return await axios.post<BookmarkFeedResponse>(`/bookmark/${feedId}`, {});
+  }
+
+  return await axios.delete<BookmarkFeedResponse>(`/bookmark/${feedId}`, {});
+}

--- a/src/services/member.ts
+++ b/src/services/member.ts
@@ -7,3 +7,14 @@ type UpdateUserDetailsResponse = '';
 export async function requestUpdateUserDetails(payload: UpdateUserDetailsPayload) {
   return await axios.put<UpdateUserDetailsResponse>(`/member/me`, payload);
 }
+
+type RequestSubscribeMemberPayload = { toMemberId: number; wouldSubscribe: boolean };
+type RequestSubscribeMemberResponse = null;
+
+export async function requestSubscribeMember({ toMemberId, wouldSubscribe }: RequestSubscribeMemberPayload) {
+  if (wouldSubscribe) {
+    return await axios.post<RequestSubscribeMemberResponse>(`/subscribe/${toMemberId}`, {});
+  }
+
+  return await axios.delete<RequestSubscribeMemberResponse>(`/subscribe/${toMemberId}`, {});
+}

--- a/src/services/vote.ts
+++ b/src/services/vote.ts
@@ -1,20 +1,22 @@
 import { axios } from '@Libs/axios';
-import { VoteResultItem } from '@Stores/vote';
+import { TFeed, TVoteCandidate, TVoteResult } from '@Types/model';
 
-/** TODO: 모델로 옮기기 */
-export type VoteCandidate = {
-  feedId: number;
-  userId: number;
-  imageURL: string;
-};
-
-type GetVoteCandidatesResponse = { voteCandidates: VoteCandidate[] };
+type GetVoteCandidatesAPIResponse = { feeds: TFeed[] };
+type GetVoteCandidatesResponse = { voteCandidates: TVoteCandidate[] };
 
 export async function requestGetVoteCandidates() {
-  return await axios.get<GetVoteCandidatesResponse>('/vote/candidates');
+  return await axios.get<GetVoteCandidatesAPIResponse>('/vote/candidates').then(
+    ({ data: { feeds } }) =>
+      ({
+        voteCandidates: feeds.map(({ id, ...feed }) => ({
+          feedId: id,
+          ...feed,
+        })),
+      }) as GetVoteCandidatesResponse
+  );
 }
 
-type SendVoteResultPayload = VoteResultItem[];
+type SendVoteResultPayload = TVoteResult[];
 
 export async function requestSendVoteResult(voteItems: SendVoteResultPayload) {
   return await axios.post('/vote/candidates', { voteItems });

--- a/src/stores/auth.ts
+++ b/src/stores/auth.ts
@@ -1,15 +1,15 @@
-import { User } from '@Types/User';
+import { UserDetail } from '@Types/User';
 import { getPayloadFromJWT } from '@Utils/index';
 import { create } from 'zustand';
 
 export type AuthStore = {
-  user: User | null;
+  user: UserDetail;
   accessToken: string | null;
   csrfToken: string | null;
   iat: Date | null;
   exp: Date | null;
 
-  setUser: ({ user }: { user: User }) => void;
+  setUser: ({ user }: { user: UserDetail }) => void;
   setAccessToken: ({ accessToken }: { accessToken: string }) => void;
   setCSRFToken: ({ csrfToken }: { csrfToken: string }) => void;
   setTokens: ({ accessToken, csrfToken }: { accessToken: string; csrfToken: string }) => void;
@@ -18,8 +18,15 @@ export type AuthStore = {
   resetAuth: () => void;
 };
 
+const initialUserDetail: UserDetail = {
+  id: -1,
+  accountId: '',
+  genderType: undefined,
+  profileImageURL: undefined,
+};
+
 export const useAuthStore = create<AuthStore>((set, get) => ({
-  user: null,
+  user: initialUserDetail,
   accessToken: null,
   csrfToken: null,
   iat: null,
@@ -44,13 +51,13 @@ export const useAuthStore = create<AuthStore>((set, get) => ({
   },
 
   setAuthFromToken({ accessToken }) {
-    const { accountId, email, exp, iat, id } = getPayloadFromJWT(accessToken);
+    const { id, username: accountId, genderType, exp, iat } = getPayloadFromJWT(accessToken);
 
-    const newUser = { id, email, accountId };
-    set({ user: newUser, exp, iat });
+    const newUser: Partial<UserDetail> = { id: +id, accountId, genderType };
+    set(({ user }) => ({ user: { ...(user || {}), newUser }, exp, iat }));
   },
 
   resetAuth() {
-    set({ user: null, accessToken: null, csrfToken: null, iat: null, exp: null });
+    set({ user: initialUserDetail, accessToken: null, csrfToken: null, iat: null, exp: null });
   },
 }));

--- a/src/stores/auth.ts
+++ b/src/stores/auth.ts
@@ -1,4 +1,4 @@
-import { UserDetail } from '@Types/User';
+import { UserDetail } from '@Types/model';
 import { getPayloadFromJWT } from '@Utils/index';
 import { create } from 'zustand';
 
@@ -8,11 +8,13 @@ export type AuthStore = {
   csrfToken: string | null;
   iat: Date | null;
   exp: Date | null;
+  isAuthentication: boolean;
 
   setUser: ({ user }: { user: UserDetail }) => void;
   setAccessToken: ({ accessToken }: { accessToken: string }) => void;
   setCSRFToken: ({ csrfToken }: { csrfToken: string }) => void;
   setTokens: ({ accessToken, csrfToken }: { accessToken: string; csrfToken: string }) => void;
+  setIsAuthentication: ({ isAuthentication }: { isAuthentication: boolean }) => void;
   setAuthFromToken: ({ accessToken }: { accessToken: string }) => void;
 
   resetAuth: () => void;
@@ -50,14 +52,23 @@ export const useAuthStore = create<AuthStore>((set, get) => ({
     get().setCSRFToken({ csrfToken });
   },
 
+  setIsAuthentication({ isAuthentication }) {
+    set({ isAuthentication });
+  },
+
   setAuthFromToken({ accessToken }) {
     const { id, username: accountId, genderType, exp, iat } = getPayloadFromJWT(accessToken);
 
     const newUser: Partial<UserDetail> = { id: +id, accountId, genderType };
-    set(({ user }) => ({ user: { ...(user || {}), newUser }, exp, iat }));
+    set(({ user }) => ({
+      isAuthentication: true,
+      user: { ...user, ...newUser },
+      exp,
+      iat,
+    }));
   },
 
   resetAuth() {
-    set({ user: initialUserDetail, accessToken: null, csrfToken: null, iat: null, exp: null });
+    set({ user: initialUserDetail, isAuthentication: false, accessToken: null, csrfToken: null, iat: null, exp: null });
   },
 }));

--- a/src/stores/vote.ts
+++ b/src/stores/vote.ts
@@ -1,26 +1,12 @@
+import { TVoteCandidateCard, TVoteResult } from '@Types/model';
 import { generateRandomId } from '@Utils/index';
 import { create } from 'zustand';
 
-export type VoteCandidateCardType = {
-  feedId: number;
-  userId: number;
-  imageURL: string;
-  anonName: string;
-};
-
 export type SwipeDirection = 'left' | 'right';
-
-export type VoteType = 'FADE_IN' | 'FADE_OUT';
-
-export type VoteResultItem = {
-  feedId: number;
-  voteType: VoteType;
-};
-
 interface VotingState {
   cycleId: string; // 현재 투표 사이클 Id
-  viewCards: VoteCandidateCardType[]; // 현재 투표 선택지
-  voteResults: VoteResultItem[]; // 투표 결과를 담아놓는 곳
+  viewCards: TVoteCandidateCard[]; // 현재 투표 선택지
+  voteResults: TVoteResult[]; // 투표 결과를 담아놓는 곳
   hasVotedToday: boolean; // 오늘 투표를 진행했는지?
   isVotingInProgress: boolean; // 현재 투표 중인지?
   votingCountToday: number; // 오늘 투표한 횟수
@@ -28,8 +14,8 @@ interface VotingState {
   swipeDirection: SwipeDirection; // 애니메이션을 위한 스와이프 방향
 
   generateNewCycleId: () => void;
-  setViewCards: (viewCards: VoteCandidateCardType[]) => void;
-  updateVoteResult: (voteResult: VoteResultItem) => void;
+  setViewCards: (viewCards: TVoteCandidateCard[]) => void;
+  updateVoteResult: (voteResult: TVoteResult) => void;
   clearVoteResults: () => void;
   setHasVotedToday: (hasVoted: boolean) => void;
   setIsVotingInProgress: (isInProgress: boolean) => void;

--- a/src/types/User.ts
+++ b/src/types/User.ts
@@ -1,4 +1,4 @@
-export type GenderType = 'men' | 'women';
+export type GenderType = 'MALE' | 'FEMALE';
 
 export interface User {
   id: string;
@@ -20,5 +20,5 @@ export interface UserDetail {
 
 export type AuthTokens = {
   accessToken: string;
-  csrfToken: string;
+  // csrfToken: string; // 보류
 };

--- a/src/types/User.ts
+++ b/src/types/User.ts
@@ -11,14 +11,12 @@ export interface User {
 
 export interface UserDetail {
   id: number;
-  email: string;
   accountId: string;
-  profileImageId: number;
-  profileImageURL: string;
-  gender?: GenderType;
+  profileImageURL?: string;
+  genderType?: GenderType;
 }
 
 export type AuthTokens = {
   accessToken: string;
-  // csrfToken: string; // 보류
+  csrfToken?: string; // 보류
 };

--- a/src/types/model.ts
+++ b/src/types/model.ts
@@ -1,14 +1,5 @@
 export type GenderType = 'MALE' | 'FEMALE';
 
-export interface User {
-  id: string;
-  email: string;
-  accountId: string;
-  profileImageId: number;
-  profileImageURL: string;
-  gender?: string;
-}
-
 export interface UserDetail {
   id: number;
   accountId: string;
@@ -16,7 +7,7 @@ export interface UserDetail {
   genderType?: GenderType;
 }
 
-export type AuthTokens = {
+export interface AuthTokens {
   accessToken: string;
   csrfToken?: string; // 보류
-};
+}

--- a/src/types/model.ts
+++ b/src/types/model.ts
@@ -29,6 +29,8 @@ export interface TOutfitItem {
 
 export interface TVoteCandidate extends Omit<TFeed, 'id'> {
   feedId: number;
+  isSubscribed: boolean;
+  isBookmarked: boolean;
 }
 
 export interface TVoteCandidateCard extends TVoteCandidate {

--- a/src/types/model.ts
+++ b/src/types/model.ts
@@ -11,3 +11,39 @@ export interface AuthTokens {
   accessToken: string;
   csrfToken?: string; // 보류
 }
+
+export interface TFeed {
+  id: number;
+  memberId: number;
+  imageURL: string;
+  styleIds: number[];
+  outfits: TOutfitItem[];
+}
+
+export interface TOutfitItem {
+  id: number;
+  brandName: string;
+  details: string;
+  categoryId: number;
+}
+
+export interface TVoteCandidate extends Omit<TFeed, 'id'> {
+  feedId: number;
+}
+
+export interface TVoteCandidateCard extends TVoteCandidate {
+  anonName: string;
+}
+
+export interface TVoteResult {
+  feedId: number;
+  voteType: VoteType;
+}
+
+export type VoteType = 'FADE_IN' | 'FADE_OUT';
+
+/**
+ * TFeed
+ *  TVoteCandidate
+ *    TVoteCandidateCard
+ */

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,5 +1,6 @@
 import { LoaderResponse, LoaderResponseStatus } from '@Types/loaderResponse';
 import { ServiceErrorResponse } from '@Types/serviceError';
+import { GenderType } from '@Types/User';
 import { isAxiosError } from 'axios';
 import { type ClassValue, clsx } from 'clsx';
 import { isAfter, isBefore, isSameMonth, isSameYear } from 'date-fns';
@@ -13,8 +14,8 @@ export function cn(...inputs: ClassValue[]) {
 export function getPayloadFromJWT(jwt: string) {
   return JSON.parse(atob(jwt.split('.')[1]).replaceAll('\\', '')) as {
     id: string;
-    accountId: string;
-    email: string;
+    username: string; // accountId
+    genderType: GenderType;
     exp: Date;
     iat: Date;
   };


### PR DESCRIPTION
### 관련된 이슈 번호를 기입해주세요.
> `close #이슈번호` 와 같은 형식으로 작성해주세요.

- close #137

### 어떤 부분이 변경됐나요?
> 어떤 부분을 변경했는지, 무슨 이유로 코드를 변경했는지 설명해주세요.

**스프링 API 서버에서 배포한 Auth API 명세대로 API를 대응했습니다.**
- 로직은 크게 바뀐 것은 없고 명칭 관련으로 리팩토링 진행했습니다.
- CSRF Token은 보류하기로 결정했습니다.
- 이에 맞게끔 API 모킹을 진행했습니다.

**Auth에 맞게 유저 타입을 재지정했습니다.**
- 기존 User 타입을 UserDetail로 변경하고, null 대신 기본 값이 지정됩니다.
  - id가 -1일 시 미지정 입니다.

**투표에 관한 타입을 작성했습니다.**
- 피드를 기반으로 하는 타입이므로 먼저 피드 모델 타입을 생성했습니다. (TFeed)
- 이를 확장하여 투표에 필요한 모델 타입을 작성했습니다.  (TVoteCandidate, TVoteCandidateCard, TVoteResult)
- 투표 목록 조회에 대해 더미를 생성하여 보내주는 Mocking Helper Function을 작성했습니다.

**구독하기 및 북마크 API를 연동했습니다.**
- 둘 다 토글 형태의 API 이므로 Optimistic Update로 처리했습니다.

### 추가 정보 (선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.

- 해당 없음
