### PR TITLE
사진 상세 화면 작성 및 API 연동 & 구독 탭 API 연동 & 사진 상세 다이얼로그 연동

### DIFF
--- a/src/__mock__/handlers.ts
+++ b/src/__mock__/handlers.ts
@@ -9,6 +9,7 @@ import {
   generateDummyFashionFeed,
   generateDummyFeedData,
   generateDummyFeedDetail,
+  generateDummySubscribersWithPagination,
   generateTVoteCandidateDummyData,
 } from './utils';
 
@@ -284,5 +285,16 @@ export const handlers = [
     const result = fetchingType === 'SUBSCRIBE' ? generateDummyFeedDetail(5, +nextCursor) : generateDummyFashionFeed(12, +nextCursor);
 
     return HttpResponse.json({ ...result }, { status: HttpStatusCode.Ok });
+  }),
+
+  http.get(`${BASE_URL}/subscribe/subscribers`, async ({ request }) => {
+    const { searchParams } = new URL(request.url);
+    const nextCursor = searchParams.get('nextCursor')!;
+
+    await delay(NETWORK_DELAY);
+
+    const subscribers = generateDummySubscribersWithPagination(12, +nextCursor);
+
+    return HttpResponse.json(subscribers, { status: HttpStatusCode.Ok });
   }),
 ];

--- a/src/__mock__/handlers.ts
+++ b/src/__mock__/handlers.ts
@@ -3,7 +3,14 @@ import { ServiceErrorResponse } from '@Types/serviceError';
 import { HttpStatusCode } from 'axios';
 import { addDays, getMonth, getYear } from 'date-fns';
 import { HttpResponse, delay, http } from 'msw';
-import { createAccessToken, createRefreshToken, generateDummyFashionFeed, generateDummyFeedData, generateTVoteCandidateDummyData } from './utils';
+import {
+  createAccessToken,
+  createRefreshToken,
+  generateDummyFashionFeed,
+  generateDummyFeedData,
+  generateDummyFeedDetail,
+  generateTVoteCandidateDummyData,
+} from './utils';
 
 import testFashionImage1 from '@Assets/test_fashion_image.jpg';
 import testFashionImage10 from '@Assets/test_fashion_image_10.jpg';
@@ -270,10 +277,11 @@ export const handlers = [
   http.get(`${BASE_URL}/feeds`, async ({ request }) => {
     const { searchParams } = new URL(request.url);
     const nextCursor = searchParams.get('nextCursor')!;
+    const fetchingType = searchParams.get('fetchingType')!;
 
     await delay(NETWORK_DELAY);
 
-    const result = generateDummyFashionFeed(12, +nextCursor);
+    const result = fetchingType === 'SUBSCRIBE' ? generateDummyFeedDetail(5, +nextCursor) : generateDummyFashionFeed(12, +nextCursor);
 
     return HttpResponse.json({ ...result }, { status: HttpStatusCode.Ok });
   }),

--- a/src/__mock__/utils.ts
+++ b/src/__mock__/utils.ts
@@ -1,4 +1,4 @@
-import { TAllFashionFeedAPI, TFAPArchivingFeedAPI, TFeedAdittionalDetail, TFeedDetail, TOutfitItem, TStyleId, TVoteCandidateAPI, UserDetail } from '@Types/model';
+import { TAllFashionFeedAPI, TFAPArchivingFeedAPI, TFeedAdittionalDetail, TFeedDetail, TOutfitItem, TStyleId, TSubscriberAPI, TVoteCandidateAPI, UserDetail } from '@Types/model';
 import { addDays, addHours } from 'date-fns';
 
 import testFashionImage1 from '@Assets/test_fashion_image.jpg';
@@ -241,6 +241,35 @@ export function generateDummyFeedDetail(count: number = 10, startCursor: number 
 
   return {
     feeds,
+    nextCursor: startCursor + count,
+  };
+}
+
+function generateRandomSubscriber(): TSubscriberAPI {
+  const id = Math.floor(Math.random() * 10000) + 1;
+  return {
+    id,
+    username: `user${id}`,
+    profileImageURL: testFahsionImages[getRandomNumber(0, testFahsionImages.length - 1)],
+  };
+}
+
+export function generateDummySubscribers(count: number = 10): TSubscriberAPI[] {
+  return Array(count)
+    .fill(null)
+    .map(() => generateRandomSubscriber());
+}
+
+export function generateDummySubscribersWithPagination(count: number = 10, startCursor: number = 0): InfiniteResponse<{ subscribers: TSubscriberAPI[] }> {
+  const subscribers = Array(count)
+    .fill(null)
+    .map((_, index) => ({
+      ...generateRandomSubscriber(),
+      id: startCursor + index + 1,
+    }));
+
+  return {
+    subscribers,
     nextCursor: startCursor + count,
   };
 }

--- a/src/__mock__/utils.ts
+++ b/src/__mock__/utils.ts
@@ -1,4 +1,4 @@
-import { TAllFashionFeedAPI, TFAPArchivingFeedAPI, TOutfitItem, TStyleId, TVoteCandidateAPI, UserDetail } from '@Types/model';
+import { TAllFashionFeedAPI, TFAPArchivingFeedAPI, TFeedAdittionalDetail, TFeedDetail, TOutfitItem, TStyleId, TVoteCandidateAPI, UserDetail } from '@Types/model';
 import { addDays, addHours } from 'date-fns';
 
 import testFashionImage1 from '@Assets/test_fashion_image.jpg';
@@ -166,18 +166,19 @@ function generateRandomOutfit(): TOutfitItem {
     id: Math.floor(Math.random() * 1000),
     brandName: ['Nike', 'Adidas', 'Gucci', 'Zara', 'H&M'][Math.floor(Math.random() * 5)],
     details: `Item details ${Math.random().toString(36).substring(7)}`,
-    categoryId: Math.floor(Math.random() * 10) + 1,
+    categoryId: Math.floor(Math.random() * 5) + 1,
   };
 }
 
 function generateRandomStyleId(): TStyleId {
-  return { id: Math.floor(Math.random() * 100) + 1 };
+  return { id: Math.floor(Math.random() * 30) + 1 };
 }
 
 function generateRandomFeed(id: number): TAllFashionFeedAPI {
   return {
     id,
     memberId: Math.floor(Math.random() * 1000) + 1,
+    username: getRandomString(10),
     imageURL: testFahsionImages[getRandomNumber(0, testFahsionImages.length - 1)],
     styleIds: Array(Math.floor(Math.random() * 5) + 1)
       .fill(null)
@@ -193,6 +194,50 @@ export function generateDummyFashionFeed(count: number = 10, startCursor: number
   const feeds = Array(count)
     .fill(null)
     .map((_, index) => generateRandomFeed(startCursor + index + 1));
+
+  return {
+    feeds,
+    nextCursor: startCursor + count,
+  };
+}
+
+function generateRandomFeedDetail(id: number): TFeedDetail {
+  const baseFeed = generateRandomFeed(id);
+  const baseDetail: TFeedDetail = {
+    ...baseFeed,
+    profileImageURL: testFahsionImages[getRandomNumber(0, testFahsionImages.length - 1)],
+    feedId: baseFeed.id,
+    isFAPFeed: Math.random() < 0.5,
+    isSubscribed: Math.random() < 0.5,
+    isBookmarked: Math.random() < 0.5,
+    isMine: Math.random() < 0.3,
+  };
+
+  if (baseDetail.isMine) {
+    const mineDetail: TFeedDetail & TFeedAdittionalDetail = {
+      ...baseDetail,
+      isMine: true,
+      isSubscribed: undefined as never,
+      fadeInCount: Math.floor(Math.random() * 1000),
+      bookmarkCount: Math.floor(Math.random() * 500),
+      reportCount: Math.floor(Math.random() * 10),
+    };
+    return mineDetail;
+  } else if (Math.random() < 0.5) {
+    const voteDetail: TFeedDetail = {
+      ...baseDetail,
+      votedAt: generateRandomDate(new Date(2023, 0, 1), new Date()),
+    };
+    return voteDetail;
+  }
+
+  return baseDetail;
+}
+
+export function generateDummyFeedDetail(count: number = 10, startCursor: number = 0): InfiniteResponse<{ feeds: TFeedDetail[] }> {
+  const feeds = Array(count)
+    .fill(null)
+    .map((_, index) => generateRandomFeedDetail(startCursor + index + 1));
 
   return {
     feeds,

--- a/src/components/BookmarkButton.tsx
+++ b/src/components/BookmarkButton.tsx
@@ -1,0 +1,68 @@
+import { Button } from '@Components/ui/button';
+import { useToastActions } from '@Hooks/toast';
+import { requestBookmarkFeed } from '@Services/feed';
+import { useMutation } from '@tanstack/react-query';
+import { cn } from '@Utils/index';
+import { useEffect, useState } from 'react';
+import { MdBookmark } from 'react-icons/md';
+import { VscLoading } from 'react-icons/vsc';
+
+interface TBookmarkButton {
+  feedId: number;
+  defaultBookmarkStatus: boolean;
+  size?: 'default' | 'lg';
+}
+
+type BookmarkButtonProps = TBookmarkButton;
+
+export function BookmarkButton({ feedId, defaultBookmarkStatus, size = 'default' }: BookmarkButtonProps) {
+  const [isBookmarked, setIsBookmarked] = useState(defaultBookmarkStatus);
+  const { showToast } = useToastActions();
+
+  const { mutate: bookmarkFeed, isPending } = useMutation({
+    mutationKey: ['bookmarkFeed'],
+    mutationFn: requestBookmarkFeed,
+  });
+
+  useEffect(() => {
+    setIsBookmarked(defaultBookmarkStatus);
+  }, [defaultBookmarkStatus]);
+
+  const handleClick = () => {
+    setIsBookmarked((prev) => !prev);
+
+    bookmarkFeed(
+      {
+        feedId,
+        wouldBookmark: !defaultBookmarkStatus,
+      },
+      {
+        onError() {
+          setIsBookmarked((prev) => !prev);
+          showToast({ type: 'error', title: '북마크에 실패했어요.' });
+        },
+      }
+    );
+  };
+
+  return (
+    <Button
+      variants="white"
+      interactive="onlyScale"
+      className={cn({
+        ['bg-purple-500']: isBookmarked,
+        ['border border-gray-100 py-1']: size === 'default',
+      })}
+      disabled={isPending}
+      onClick={handleClick}>
+      {isPending && <VscLoading className={cn('size-6 animate-spin text-gray-600')} />}
+      {!isPending && (
+        <MdBookmark
+          className={cn('size-6 text-gray-600 transition-colors', {
+            ['text-white']: isBookmarked,
+          })}
+        />
+      )}
+    </Button>
+  );
+}

--- a/src/components/FeedDetailCard.tsx
+++ b/src/components/FeedDetailCard.tsx
@@ -1,0 +1,121 @@
+import { OUTFIT_STYLE_LIST } from '@/constants';
+import { ItemBadge } from '@Components/ItemBadge';
+import { ReportButton } from '@Components/ReportButton';
+import { SubscribeButton } from '@Components/SubscribeButton';
+import { Avatar } from '@Components/ui/avatar';
+import { Image } from '@Components/ui/image';
+import { isTFeedDetailMine, isTFeedDetailVote, TFeedAdittionalDetail, TFeedDetail } from '@Types/model';
+import { cn } from '@Utils/index';
+import { format } from 'date-fns';
+import { ko } from 'date-fns/locale';
+import { motion } from 'framer-motion';
+import { MdBookmark, MdHowToVote, MdReport } from 'react-icons/md';
+import { useNavigate } from 'react-router-dom';
+import { BookmarkButton } from './BookmarkButton';
+import { OutfitCard } from './OutfitCard';
+import { Button } from './ui/button';
+import { ReactNode } from 'react';
+
+export function FeedDetailCard(feedDetail: TFeedDetail) {
+  const isVoteType = isTFeedDetailVote(feedDetail);
+  const isMineType = isTFeedDetailMine(feedDetail);
+
+  const { accountId, createdAt, feedId, imageURL, isBookmarked, isFAPFeed, isMine, isSubscribed, memberId, outfits, styleIds, profileImageURL } = feedDetail;
+
+  const haveStyleIds = styleIds.length !== 0;
+
+  const haveOutfits = outfits.length !== 0;
+  const haveOutfitsMoreThanOwn = outfits.length > 1;
+
+  return (
+    <div className="flex h-full snap-start border border-red-500">
+      <section className="flex h-full w-full flex-col gap-3 p-5">
+        {isVoteType && <p className="text-h6">{format(feedDetail.votedAt, 'yyyy년 M월 dd일 eeee', { locale: ko })}</p>}
+        {!isVoteType && <p className="text-h6">{format(feedDetail.createdAt, 'yyyy년 M월 dd일 eeee', { locale: ko })}</p>}
+
+        <Image
+          src={imageURL}
+          className={cn('relative w-full flex-1 rounded-lg bg-gray-200', {
+            ['boder-2 border-purple-500']: isFAPFeed,
+          })}
+          size="contain">
+          {!isMine && (
+            <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} className={cn('absolute right-4 top-4')}>
+              <ReportButton feedId={feedId} />
+            </motion.div>
+          )}
+        </Image>
+
+        {isMineType && <FeedAdiitionalDetails {...feedDetail} />}
+        {!isMineType && <MemberDetailCard {...feedDetail} />}
+        {haveStyleIds && <StyleCard {...feedDetail} />}
+        {haveOutfits && <OutfitCard {...outfits.at(0)!} wouldShowDetail={false} />}
+        {haveOutfitsMoreThanOwn && <ShowAllOutfitsButton />}
+      </section>
+    </div>
+  );
+}
+
+function AccountIdButton({ userId, accountId }: { userId: number; accountId: string }) {
+  const navigate = useNavigate();
+
+  return (
+    <div className="flex-1 text-left">
+      <Button variants="ghost" interactive="onlyScale" className="px-0 py-1 font-normal" onClick={() => navigate('/user', { state: { userId } })}>
+        {accountId}
+      </Button>
+    </div>
+  );
+}
+
+function StyleCard({ styleIds }: TFeedDetail) {
+  return (
+    <div>
+      <ul className="flex flex-row gap-2 overflow-y-scroll whitespace-nowrap">
+        {styleIds.map((value, index) => (
+          <ItemBadge key={`style-badge-${index}`} variants="primary">
+            {OUTFIT_STYLE_LIST.at(value)}
+          </ItemBadge>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+function MemberDetailCard({ profileImageURL, memberId, isSubscribed, isBookmarked, feedId, accountId }: TFeedDetail) {
+  return (
+    <div className="flex flex-row items-center justify-center gap-3 rounded-lg bg-white">
+      <Avatar src={profileImageURL} size="32" />
+      <AccountIdButton userId={memberId} accountId={accountId} />
+      <SubscribeButton userId={memberId} initialSubscribedStatus={isSubscribed} onToggle={() => {}} />
+      <BookmarkButton feedId={feedId} defaultBookmarkStatus={isBookmarked} />
+    </div>
+  );
+}
+
+function FeedAdiitionalDetails({ bookmarkCount, fadeInCount, reportCount }: TFeedAdittionalDetail) {
+  return (
+    <ul className="flew-row flex gap-2">
+      <FeedAdiitionalDetailItem IconRender={<MdHowToVote className="mx-auto size-5" />} detailName="FADE IN" count={fadeInCount} />
+      <FeedAdiitionalDetailItem IconRender={<MdBookmark className="mx-auto size-5 text-purple-500" />} detailName="북마크" count={bookmarkCount} />
+      <FeedAdiitionalDetailItem IconRender={<MdReport className="mx-auto size-5 text-pink-400" />} detailName="신고" count={reportCount} />
+    </ul>
+  );
+}
+
+function FeedAdiitionalDetailItem({ IconRender, detailName, count }: { IconRender: ReactNode; detailName: string; count: number }) {
+  return (
+    <li className="gap borer-gray-200 flex flex-1 flex-col items-center justify-center gap-1 rounded-lg border py-3">
+      <div className="space-y-0.5">
+        {IconRender}
+        <p>{detailName}</p>
+      </div>
+
+      <span className="font-semibold">{count}</span>
+    </li>
+  );
+}
+
+function ShowAllOutfitsButton() {
+  return <Button variants="ghost">착장 정보 전체보기</Button>;
+}

--- a/src/components/FeedDetailCard.tsx
+++ b/src/components/FeedDetailCard.tsx
@@ -1,4 +1,5 @@
 import { OUTFIT_STYLE_LIST } from '@/constants';
+import fapBadgeImage from '@Assets/fap_badge.png';
 import { ItemBadge } from '@Components/ItemBadge';
 import { ReportButton } from '@Components/ReportButton';
 import { SubscribeButton } from '@Components/SubscribeButton';
@@ -9,34 +10,50 @@ import { cn } from '@Utils/index';
 import { format } from 'date-fns';
 import { ko } from 'date-fns/locale';
 import { motion } from 'framer-motion';
+import { ReactNode, useEffect, useRef } from 'react';
 import { MdBookmark, MdHowToVote, MdReport } from 'react-icons/md';
 import { useNavigate } from 'react-router-dom';
 import { BookmarkButton } from './BookmarkButton';
 import { OutfitCard } from './OutfitCard';
 import { Button } from './ui/button';
-import { ReactNode } from 'react';
 
-export function FeedDetailCard(feedDetail: TFeedDetail) {
+interface TFeedDetailCard {
+  focus?: boolean;
+}
+
+type FeedDetailCardProps = TFeedDetailCard & TFeedDetail;
+
+export function FeedDetailCard({ focus, ...feedDetail }: FeedDetailCardProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
   const isVoteType = isTFeedDetailVote(feedDetail);
   const isMineType = isTFeedDetailMine(feedDetail);
 
-  const { accountId, createdAt, feedId, imageURL, isBookmarked, isFAPFeed, isMine, isSubscribed, memberId, outfits, styleIds, profileImageURL } = feedDetail;
+  const { feedId, imageURL, isFAPFeed, isMine, outfits, styleIds } = feedDetail;
 
   const haveStyleIds = styleIds.length !== 0;
 
   const haveOutfits = outfits.length !== 0;
   const haveOutfitsMoreThanOwn = outfits.length > 1;
 
+  useEffect(() => {
+    if (containerRef.current == null) {
+      return;
+    }
+
+    focus && containerRef.current.scrollIntoView({ behavior: 'smooth' });
+  }, [focus, containerRef.current]);
+
   return (
-    <div className="flex h-full snap-start border border-red-500">
-      <section className="flex h-full w-full flex-col gap-3 p-5">
+    <div ref={containerRef} className="flex h-full snap-start border border-red-500">
+      <section className="relative flex h-full w-full flex-col gap-3 p-5">
+        {isFAPFeed && <Image src={fapBadgeImage} className="absolute right-5 top-3 size-10" />}
         {isVoteType && <p className="text-h6">{format(feedDetail.votedAt, 'yyyy년 M월 dd일 eeee', { locale: ko })}</p>}
         {!isVoteType && <p className="text-h6">{format(feedDetail.createdAt, 'yyyy년 M월 dd일 eeee', { locale: ko })}</p>}
 
         <Image
           src={imageURL}
           className={cn('relative w-full flex-1 rounded-lg bg-gray-200', {
-            ['boder-2 border-purple-500']: isFAPFeed,
+            ['border-2 border-purple-500']: isFAPFeed,
           })}
           size="contain">
           {!isMine && (

--- a/src/components/FeedDetailDialog.tsx
+++ b/src/components/FeedDetailDialog.tsx
@@ -1,0 +1,34 @@
+import { FlexibleLayout } from '@Layouts/FlexibleLayout';
+import { DefaultModalProps } from '@Stores/modal';
+import { TFeedDetail } from '@Types/model';
+import { FeedDetailCard } from './FeedDetailCard';
+import { BackButton } from './ui/button';
+
+type FeedDialogDialogProps = { feeds: TFeedDetail[]; defaultViewIndex: number };
+
+export function FeedDetailDialog({ feeds, defaultViewIndex, onClose }: DefaultModalProps<void, FeedDialogDialogProps>) {
+  return (
+    <FlexibleLayout.Root>
+      <FlexibleLayout.Header>
+        <header className="relative py-2">
+          <BackButton onClick={onClose} />
+          <p className="text-center text-2xl font-semibold">사진 상세</p>
+        </header>
+      </FlexibleLayout.Header>
+
+      <FlexibleLayout.Content>
+        <Feeds feeds={feeds} defaultViewIndex={defaultViewIndex} />
+      </FlexibleLayout.Content>
+    </FlexibleLayout.Root>
+  );
+}
+
+function Feeds({ feeds, defaultViewIndex }: { feeds: TFeedDetail[]; defaultViewIndex: number }) {
+  return (
+    <div id="feedList" className="h-full snap-y snap-mandatory overflow-y-scroll">
+      {feeds.map((feedDetail, index) => (
+        <FeedDetailCard key={feedDetail.feedId} {...feedDetail} focus={index === defaultViewIndex} />
+      ))}
+    </div>
+  );
+}

--- a/src/components/OutfitCard.tsx
+++ b/src/components/OutfitCard.tsx
@@ -1,0 +1,22 @@
+import { OUTFIT_CATEGORY_LIST } from '@/constants';
+import { TOutfitItem } from '@Types/model';
+import { ItemBadge } from './ItemBadge';
+
+interface TOutfitCard {
+  wouldShowDetail?: boolean;
+}
+
+type OutfitCardProps = TOutfitCard & Omit<TOutfitItem, 'id'>;
+
+export function OutfitCard({ brandName, categoryId, details, wouldShowDetail = true }: OutfitCardProps) {
+  return (
+    <div className="flex w-full flex-row gap-3 rounded-lg border border-purple-50 bg-white p-3">
+      <ItemBadge variants="primary">{OUTFIT_CATEGORY_LIST.at(categoryId)}</ItemBadge>
+
+      <div className="flex w-full flex-col justify-center gap-1">
+        <p className="text-left">{brandName}</p>
+        {wouldShowDetail && <p className="text-left text-sm text-gray-500">{details}</p>}
+      </div>
+    </div>
+  );
+}

--- a/src/components/SubscribeButton.tsx
+++ b/src/components/SubscribeButton.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from 'react';
 import { Button } from './ui/button';
 import { requestSubscribeMember } from '@Services/member';
 import { useToastActions } from '@Hooks/toast';
+import { VscLoading } from 'react-icons/vsc';
 
 type SubscribeButtonSize = 'default' | 'lg';
 
@@ -62,6 +63,7 @@ export function SubscribeButton({ size = 'default', userId, initialSubscribedSta
       onClick={handleClick}>
       {isSubscribed && '구독중'}
       {!isSubscribed && '구독'}
+      {isPending && <VscLoading className={cn('ml-1 inline-block size-3 animate-spin text-gray-600')} />}
     </Button>
   );
 }

--- a/src/components/ui/image.tsx
+++ b/src/components/ui/image.tsx
@@ -26,7 +26,7 @@ export function Image({ children, src, className, alt, size = 'cover' }: PropsWi
       role="img"
       aria-label={alt}
       style={{ backgroundImage: imageURL ? `url('${imageURL}')` : 'none' }}
-      className={cn('relative h-full w-full bg-center bg-no-repeat', className, {
+      className={cn('relative grid h-full w-full place-content-center bg-center bg-no-repeat', className, {
         ['bg-cover']: size === 'cover',
         ['bg-contain']: size === 'contain',
       })}>

--- a/src/hooks/useHeader.ts
+++ b/src/hooks/useHeader.ts
@@ -12,5 +12,5 @@ export function useHeader({ title, leftSlot, rightSlot }: UseHeaderProps) {
     setTitle(title);
     setLeftSlot(leftSlot);
     setRightSlot(rightSlot);
-  }, []);
+  }, [title, leftSlot, rightSlot]);
 }

--- a/src/hooks/useInfiniteObserver.ts
+++ b/src/hooks/useInfiniteObserver.ts
@@ -31,7 +31,7 @@ export function useInfiniteObserver({ parentNodeId, onIntersection }: { parentNo
 
   useEffect(() => {
     mutationObserver.observe(document.getElementById(parentNodeId)!, { childList: true });
-    intersectionObserver.observe(document.getElementById(parentNodeId)!.lastElementChild!);
+    intersectionObserver.observe(document.getElementById(parentNodeId)!.lastElementChild || document.getElementById(parentNodeId)!);
 
     return () => disconnect();
   }, []);

--- a/src/hooks/useInfiniteObserver.ts
+++ b/src/hooks/useInfiniteObserver.ts
@@ -1,6 +1,8 @@
 import { useEffect, useMemo } from 'react';
 
 export function useInfiniteObserver({ parentNodeId, onIntersection }: { parentNodeId: string; onIntersection: () => void }) {
+  const targetParentNode = document.getElementById(parentNodeId);
+
   const intersectionObserver = useMemo(
     () =>
       new IntersectionObserver(
@@ -10,7 +12,7 @@ export function useInfiniteObserver({ parentNodeId, onIntersection }: { parentNo
         },
         { threshold: 0.1 }
       ),
-    []
+    [parentNodeId]
   );
 
   const mutationObserver = useMemo(
@@ -21,7 +23,7 @@ export function useInfiniteObserver({ parentNodeId, onIntersection }: { parentNo
         intersectionObserver.disconnect();
         intersectionObserver.observe(lastNode as Element);
       }),
-    []
+    [parentNodeId]
   );
 
   const disconnect = () => {
@@ -30,11 +32,15 @@ export function useInfiniteObserver({ parentNodeId, onIntersection }: { parentNo
   };
 
   useEffect(() => {
+    if (targetParentNode === null) {
+      return;
+    }
+
     mutationObserver.observe(document.getElementById(parentNodeId)!, { childList: true });
     intersectionObserver.observe(document.getElementById(parentNodeId)!.lastElementChild || document.getElementById(parentNodeId)!);
 
     return () => disconnect();
-  }, []);
+  }, [targetParentNode, mutationObserver, intersectionObserver]);
 
   return { disconnect };
 }

--- a/src/pages/Root/_dialogs/UploadDialog/components/UploadImageForm.tsx
+++ b/src/pages/Root/_dialogs/UploadDialog/components/UploadImageForm.tsx
@@ -1,6 +1,7 @@
 import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from '@/components/ui/form';
-import { OUTFIT_CATEGORY_LIST, OUTFIT_STYLE_MAP } from '@/constants';
+import { OUTFIT_STYLE_MAP } from '@/constants';
 import { ItemBadge } from '@Components/ItemBadge';
+import { OutfitCard } from '@Components/OutfitCard';
 import { Button } from '@Components/ui/button';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useModalActions } from '@Hooks/modal';
@@ -249,13 +250,8 @@ function OutfitItemCard({
   };
 
   return (
-    <button type="button" className="flex w-full flex-row gap-3 rounded-lg border border-purple-50 bg-white p-3" onClick={handleClick}>
-      <ItemBadge variants="primary">{OUTFIT_CATEGORY_LIST[outfitItem.categoryId]}</ItemBadge>
-
-      <div className="flex w-full flex-col gap-1">
-        <p className="text-left">{outfitItem.brandName}</p>
-        <p className="text-left text-sm text-gray-500">{outfitItem.details}</p>
-      </div>
+    <button type="button" className="w-full" onClick={handleClick}>
+      <OutfitCard {...outfitItem} />
     </button>
   );
 }

--- a/src/pages/Root/archive/components/AllArchivingView.tsx
+++ b/src/pages/Root/archive/components/AllArchivingView.tsx
@@ -1,9 +1,11 @@
+import { FeedDetailDialog } from '@Components/FeedDetailDialog';
 import { Button } from '@Components/ui/button';
 import { Image } from '@Components/ui/image';
 import { useModalActions } from '@Hooks/modal';
 import { useInfiniteObserver } from '@Hooks/useInfiniteObserver';
 import { requestGetAllFashionFeed } from '@Services/feed';
 import { useInfiniteQuery } from '@tanstack/react-query';
+import { TAllFashionFeed } from '@Types/model';
 import { cn } from '@Utils/index';
 import { useEffect, useState } from 'react';
 import { VscLoading } from 'react-icons/vsc';
@@ -46,13 +48,7 @@ export function AllArchivingView() {
 
       <div className="flex h-full min-h-1 flex-col overflow-y-scroll">
         <div id="feedList" className="grid w-full grid-cols-3 gap-1">
-          {data?.pages.map(({ feeds }) =>
-            feeds.map((feed) => (
-              <div key={`item-${feed.feedId}`} className="group aspect-[3/4] w-full cursor-pointer overflow-hidden rounded-lg">
-                <Image src={feed.imageURL} className="h-full w-full transition-transform group-hover:scale-105" />
-              </div>
-            ))
-          )}
+          {data?.pages.map(({ feeds }) => feeds.map((feed, index) => <FeedItem key={`item-${feed.feedId}`} feeds={feeds} index={index} {...feed} />))}
         </div>
 
         {(isFetchingNextPage || isPending) && (
@@ -63,6 +59,27 @@ export function AllArchivingView() {
 
         {!isPending && !hasNextPage && <p className="text-detail text-gray-700">모든 페이더들의 패션을 불러왔어요.</p>}
       </div>
+    </div>
+  );
+}
+
+interface TFeedItem {
+  feeds: TAllFashionFeed[];
+  index: number;
+}
+
+type FeedItemProps = TFeedItem & TAllFashionFeed;
+
+function FeedItem({ feeds, index, ...feed }: FeedItemProps) {
+  const { showModal } = useModalActions();
+
+  const handleClick = async () => {
+    await showModal({ type: 'fullScreenDialog', animateType: 'slideInFromRight', Component: FeedDetailDialog, props: { feeds, defaultViewIndex: index } });
+  };
+
+  return (
+    <div key={`item-${feed.feedId}`} className="group aspect-[3/4] w-full cursor-pointer overflow-hidden rounded-lg" onClick={handleClick}>
+      <Image src={feed.imageURL} className="h-full w-full transition-transform group-hover:scale-105" />
     </div>
   );
 }

--- a/src/pages/Root/archive/components/FAPArchivingView.tsx
+++ b/src/pages/Root/archive/components/FAPArchivingView.tsx
@@ -1,5 +1,7 @@
+import { FeedDetailDialog } from '@Components/FeedDetailDialog';
 import { Button } from '@Components/ui/button';
 import { Image } from '@Components/ui/image';
+import { useModalActions } from '@Hooks/modal';
 import { requestFAPArchiving } from '@Services/feed';
 import { useQuery } from '@tanstack/react-query';
 import { TFAPArchivingFeed } from '@Types/model';
@@ -51,7 +53,7 @@ export function FAPArchivingView() {
       <div style={{ gridRow: weeksInMonth }} className={`grid flex-1 grid-cols-7 gap-x-2 gap-y-3`}>
         <AnimatePresence initial={false}>
           {data ? (
-            data.feeds.map((feed, index) => <FAPFeeds index={index} firstDayOfWeek={firstDayOfWeek} feed={feed} />)
+            data.feeds.map((feed, index) => <FAPFeeds index={index} firstDayOfWeek={firstDayOfWeek} feed={feed} feeds={data.feeds} />)
           ) : (
             <FAPFeedsLoading days={getDaysInMonth(calenderDate)} firstDayOfWeek={firstDayOfWeek} />
           )}
@@ -122,9 +124,16 @@ interface TFAPFeeds {
   index: number;
   firstDayOfWeek: string;
   feed: TFAPArchivingFeed;
+  feeds: TFAPArchivingFeed[];
 }
 
-function FAPFeeds({ index, firstDayOfWeek, feed }: TFAPFeeds) {
+function FAPFeeds({ index, firstDayOfWeek, feed, feeds }: TFAPFeeds) {
+  const { showModal } = useModalActions();
+
+  const handleClick = async () => {
+    await showModal({ type: 'fullScreenDialog', animateType: 'slideInFromRight', Component: FeedDetailDialog, props: { feeds, defaultViewIndex: index } });
+  };
+
   return (
     <motion.div
       layout
@@ -133,7 +142,8 @@ function FAPFeeds({ index, firstDayOfWeek, feed }: TFAPFeeds) {
       animate={{ opacity: 1 }}
       exit={{ opacity: 0 }}
       className={cn('flex h-full w-full flex-col')}
-      style={{ gridColumnStart: index === 0 ? firstDayOfWeek : undefined }}>
+      style={{ gridColumnStart: index === 0 ? firstDayOfWeek : undefined }}
+      onClick={handleClick}>
       <span className="ml-1">{index + 1}</span>
       <div className="group h-full w-full cursor-pointer overflow-hidden rounded-lg">
         <Image src={feed.imageURL} className="transition-transform group-hover:scale-105" />

--- a/src/pages/Root/subscribe/list/page.tsx
+++ b/src/pages/Root/subscribe/list/page.tsx
@@ -1,31 +1,59 @@
-import testImage from '@Assets/test_fashion_image.jpg';
 import { SubscribeButton } from '@Components/SubscribeButton';
 import { Avatar } from '@Components/ui/avatar';
 import { BackButton } from '@Components/ui/button';
 import { useHeader } from '@Hooks/useHeader';
+import { useInfiniteObserver } from '@Hooks/useInfiniteObserver';
+import { requestGetSubscribers } from '@Services/member';
+import { useInfiniteQuery } from '@tanstack/react-query';
+import { TSubscriber } from '@Types/model';
+import { useEffect } from 'react';
+import { VscLoading } from 'react-icons/vsc';
 import { useNavigate } from 'react-router-dom';
 
 export default function Page() {
   const navigate = useNavigate();
-  useHeader({ title: '구독 목록', leftSlot: () => <BackButton className="left-0" onClick={() => navigate('/subscribe', { replace: true })} /> });
+
+  const { data, isPending, hasNextPage, fetchNextPage, isFetchingNextPage } = useInfiniteQuery({
+    queryKey: ['subscribe', 'subscribers'],
+    queryFn: ({ pageParam }) => requestGetSubscribers({ nextCursor: pageParam }),
+    getNextPageParam({ nextCursor }) {
+      return nextCursor || undefined;
+    },
+    initialPageParam: 0,
+  });
+
+  useHeader({
+    title: '구독 목록',
+    leftSlot: () => <BackButton className="left-0" onClick={() => navigate('/subscribe', { replace: true })} />,
+    rightSlot: () => isFetchingNextPage && <VscLoading className="size-6 animate-spin" />,
+  });
+
+  const { disconnect: disconnectObserver } = useInfiniteObserver({
+    parentNodeId: 'subscriberList',
+    onIntersection: fetchNextPage,
+  });
+
+  useEffect(() => {
+    !hasNextPage && disconnectObserver();
+  }, [hasNextPage]);
 
   return (
-    <div className="relative flex h-full flex-col">
-      <ul>
-        <li>
-          <SubscribeItem />
-        </li>
+    <div className="relative flex h-full flex-col space-y-8">
+      <ul id="subscriberList">
+        {data?.pages.map((page) => page.subscribers.map((subscriber) => <SubscribeItem key={`subscriber-${subscriber.userId}`} {...subscriber} />))}
       </ul>
+
+      {isPending && !hasNextPage && <p className="pl-3 text-detail text-gray-700">모든 페이더들의 패션을 불러왔어요.</p>}
     </div>
   );
 }
 
-function SubscribeItem() {
+function SubscribeItem({ accountId, profileImageURL, userId }: TSubscriber) {
   return (
-    <div className="fle-row flex items-center gap-3 rounded-lg bg-white p-3">
-      <Avatar src={testImage} size="40" />
-      <p className="flex-1">fade1234</p>
-      <SubscribeButton userId={0} initialSubscribedStatus={true} onToggle={() => {}} size="lg" />
+    <div className="infiniteItem fle-row flex items-center gap-3 rounded-lg bg-white p-3">
+      <Avatar src={profileImageURL} size="40" />
+      <p className="flex-1">{accountId}</p>
+      <SubscribeButton userId={userId} initialSubscribedStatus={true} onToggle={() => {}} size="lg" />
     </div>
   );
 }

--- a/src/pages/Root/subscribe/page.tsx
+++ b/src/pages/Root/subscribe/page.tsx
@@ -1,104 +1,30 @@
-import testImage from '@Assets/test_fashion_image.jpg';
 import { FeedDetailCard } from '@Components/FeedDetailCard';
 import { ShowNotificationButton } from '@Components/ShowNotificationButton';
 import { Avatar } from '@Components/ui/avatar';
 import { useHeader } from '@Hooks/useHeader';
 import { useInfiniteObserver } from '@Hooks/useInfiniteObserver';
 import { requestGetSubscribeFeeds } from '@Services/feed';
+import { requestGetSubscribers } from '@Services/member';
+import { useHeaderStore } from '@Stores/header';
 import { useInfiniteQuery } from '@tanstack/react-query';
+import { TSubscriber } from '@Types/model';
 import { cn } from '@Utils/index';
 import { useEffect } from 'react';
 import { MdChevronRight } from 'react-icons/md';
 import { VscLoading } from 'react-icons/vsc';
 import { useNavigate } from 'react-router-dom';
 
-type SubscribeBadgeType = {
-  userId: number;
-  profileURL: string;
-  accountId: string;
-};
-
-const subscribeList: SubscribeBadgeType[] = [
-  {
-    userId: 0,
-    profileURL: testImage,
-    accountId: 'testaccount',
-  },
-  {
-    userId: 1,
-    profileURL: testImage,
-    accountId: 'testaccount',
-  },
-  {
-    userId: 2,
-    profileURL: testImage,
-    accountId: 'testaccount',
-  },
-  {
-    userId: 3,
-    profileURL: testImage,
-    accountId: 'testaccount',
-  },
-  {
-    userId: 4,
-    profileURL: testImage,
-    accountId: 'testaccount',
-  },
-];
-
 export default function Page() {
-  const { data, fetchNextPage, isFetchingNextPage, isPending, hasNextPage } = useInfiniteQuery({
-    queryKey: ['subscribe', 'list'],
-    queryFn: ({ pageParam }) => requestGetSubscribeFeeds({ nextCursor: pageParam }),
-    getNextPageParam({ nextCursor }) {
-      return nextCursor || undefined;
-    },
-    initialPageParam: 0,
-  });
-
-  useHeader({
-    title: '구독',
-    leftSlot: () => (isFetchingNextPage || isPending) && <VscLoading className="size-6 animate-spin" />,
-    rightSlot: () => <ShowNotificationButton />,
-  });
-
-  const { disconnect: disconnectObserver } = useInfiniteObserver({
-    parentNodeId: 'feedList',
-    onIntersection: fetchNextPage,
-  });
-
-  useEffect(() => {
-    !hasNextPage && disconnectObserver();
-  }, [hasNextPage]);
+  useHeader({ title: '구독', rightSlot: () => <ShowNotificationButton /> });
 
   return (
     <div className="relative flex h-full flex-col">
       <div className="relative h-fit w-full px-5 py-4">
-        <div className="overflow-y-scroll">
-          <ul className="flex flex-row gap-3">
-            {subscribeList.map((subscribe) => (
-              <li
-                key={`subscribe-${subscribe.userId}`}
-                className={cn('boder-gray-200 flex h-full flex-row items-center gap-2 rounded-lg border p-2', {
-                  ['border-purple-100 bg-purple-50']: subscribe.userId === 0,
-                })}>
-                <Avatar src={subscribe.profileURL} size="32" />
-                <span>{subscribe.accountId}</span>
-              </li>
-            ))}
-          </ul>
-        </div>
-
+        <SubscriberList />
         <ShowSubscribeListViewButton />
       </div>
 
-      <div className="relative min-h-1 flex-1 snap-y snap-mandatory overflow-y-scroll">
-        <div id="feedList" className="h-full">
-          {data && data.pages.map((page) => page.feeds.map((feedDetail) => <FeedDetailCard key={feedDetail.feedId} {...feedDetail} />))}
-        </div>
-
-        {!isPending && !hasNextPage && <p className="text-detail text-gray-700">모든 페이더들의 패션을 불러왔어요.</p>}
-      </div>
+      <SubscribeFeedList />
     </div>
   );
 }
@@ -110,5 +36,75 @@ function ShowSubscribeListViewButton() {
     <button className="absolute right-5 top-1/2 -translate-y-1/2 bg-fade-gradient px-2 py-4" onClick={() => navigate('/subscribe/list')}>
       <MdChevronRight className="size-6" />
     </button>
+  );
+}
+
+function SubscribeFeedList() {
+  const setLeftSlot = useHeaderStore((state) => state.setLeftSlot);
+
+  const { data, fetchNextPage, isFetchingNextPage, isPending, hasNextPage } = useInfiniteQuery({
+    queryKey: ['subscribe', 'list'],
+    queryFn: ({ pageParam }) => requestGetSubscribeFeeds({ nextCursor: pageParam }),
+    getNextPageParam({ nextCursor }) {
+      return nextCursor || undefined;
+    },
+    initialPageParam: 0,
+  });
+
+  useEffect(() => {
+    setLeftSlot(() => isFetchingNextPage && <VscLoading className="size-6 animate-spin" />);
+  }, [isFetchingNextPage]);
+
+  const { disconnect: disconnectObserver } = useInfiniteObserver({
+    parentNodeId: 'feedList',
+    onIntersection: fetchNextPage,
+  });
+
+  useEffect(() => {
+    !hasNextPage && disconnectObserver();
+  }, [hasNextPage]);
+
+  return (
+    <div className="relative min-h-1 flex-1 snap-y snap-mandatory overflow-y-scroll">
+      {isPending && 'TODO: 로딩 화면 표출'}
+
+      <div id="feedList" className="h-full">
+        {data && data.pages.map((page) => page.feeds.map((feedDetail) => <FeedDetailCard key={feedDetail.feedId} {...feedDetail} />))}
+      </div>
+
+      {!isPending && !hasNextPage && <p className="text-detail text-gray-700">모든 페이더들의 패션을 불러왔어요.</p>}
+    </div>
+  );
+}
+
+export function SubscriberList() {
+  const { data, isPending } = useInfiniteQuery({
+    queryKey: ['subscribe', 'subscribers'],
+    queryFn: ({ pageParam }) => requestGetSubscribers({ nextCursor: pageParam }),
+    getNextPageParam({ nextCursor }) {
+      return nextCursor || undefined;
+    },
+    initialPageParam: 0,
+  });
+
+  return (
+    <div className="flex w-full overflow-y-scroll pr-10">
+      <ul className="flex flex-row gap-3">
+        {isPending && 'TODO: 로딩화면표출'}
+        {data?.pages.map((page) => page.subscribers.map((subscriber) => <SubscriberItem key={`subscriber-${subscriber.userId}`} {...subscriber} />))}
+      </ul>
+    </div>
+  );
+}
+
+function SubscriberItem({ accountId, profileImageURL, userId }: TSubscriber) {
+  return (
+    <li
+      className={cn('boder-gray-200 flex h-full flex-row items-center gap-2 rounded-lg border p-2', {
+        ['border-purple-100 bg-purple-50']: userId === 0,
+      })}>
+      <Avatar src={profileImageURL} size="32" />
+      <span>{accountId}</span>
+    </li>
   );
 }

--- a/src/pages/Root/voteFAP/components/VotingView.tsx
+++ b/src/pages/Root/voteFAP/components/VotingView.tsx
@@ -1,9 +1,8 @@
+import { BookmarkButton } from '@Components/BookmarkButton';
 import { ReportButton } from '@Components/ReportButton';
 import { SubscribeButton } from '@Components/SubscribeButton';
-import { Button } from '@Components/ui/button';
 import { Image } from '@Components/ui/image';
 import { useToastActions } from '@Hooks/toast';
-import { requestBookmarkFeed } from '@Services/feed';
 import { requestGetVoteCandidates, requestSendVoteResult } from '@Services/vote';
 import { SwipeDirection, useVotingStore } from '@Stores/vote';
 import { useMutation, useQuery } from '@tanstack/react-query';
@@ -13,7 +12,6 @@ import { cn, generateAnonName, prefetchImages } from '@Utils/index';
 import { isAxiosError } from 'axios';
 import { AnimatePresence, motion, MotionValue, useMotionValue, useTransform, Variants } from 'framer-motion';
 import { useEffect, useLayoutEffect, useState, useTransition } from 'react';
-import { MdBookmark } from 'react-icons/md';
 import { RandomAvatar } from './RandomAvatar';
 
 import swipeFadeInImage from '@Assets/swipe_fade_in.png';
@@ -465,60 +463,5 @@ function VoteButton({ type, onClick }: VoteButtonProps) {
         })}
       />
     </button>
-  );
-}
-
-interface TBookmarkButton {
-  feedId: number;
-  defaultBookmarkStatus: boolean;
-}
-
-type BookmarkButtonProps = TBookmarkButton;
-
-function BookmarkButton({ feedId, defaultBookmarkStatus }: BookmarkButtonProps) {
-  const [isBookmarked, setIsBookmarked] = useState(defaultBookmarkStatus);
-  const { showToast } = useToastActions();
-
-  const { mutate: bookmarkFeed, isPending } = useMutation({
-    mutationKey: ['bookmarkFeed'],
-    mutationFn: requestBookmarkFeed,
-  });
-
-  useEffect(() => {
-    setIsBookmarked(defaultBookmarkStatus);
-  }, [defaultBookmarkStatus]);
-
-  const handleClick = () => {
-    setIsBookmarked((prev) => !prev);
-
-    bookmarkFeed(
-      {
-        feedId,
-        wouldBookmark: !defaultBookmarkStatus,
-      },
-      {
-        onError() {
-          setIsBookmarked((prev) => !prev);
-          showToast({ type: 'error', title: '북마크에 실패했어요.' });
-        },
-      }
-    );
-  };
-
-  return (
-    <Button
-      variants="white"
-      interactive="onlyScale"
-      className={cn('shadow-bento', {
-        ['bg-purple-500']: isBookmarked,
-      })}
-      disabled={isPending}
-      onClick={handleClick}>
-      <MdBookmark
-        className={cn('size-6 text-gray-600 transition-colors', {
-          ['text-white']: isBookmarked,
-        })}
-      />
-    </Button>
   );
 }

--- a/src/services/feed.ts
+++ b/src/services/feed.ts
@@ -1,6 +1,6 @@
 import { axios } from '@Libs/axios';
 import { FilterType } from '@Pages/Root/archive/components/SelectFilterDialog';
-import { TAllFashionFeed, TAllFashionFeedAPI, TFAPArchivingFeed, TFAPArchivingFeedAPI } from '@Types/model';
+import { TAllFashionFeed, TAllFashionFeedAPI, TFAPArchivingFeed, TFAPArchivingFeedAPI, TFeedDetail, TFeedDetailAPI } from '@Types/model';
 import { InfiniteResponse } from '@Types/response';
 import { objectToQueryParam } from '@Utils/index';
 
@@ -60,5 +60,24 @@ export async function requestGetAllFashionFeed({ filters, nextCursor }: GetAllFa
           ...feed,
         })),
       }) as GetAllFashionFeedResponse
+  );
+}
+
+type GetSubscribeFeedsPayload = { nextCursor: number };
+type GetSubscribeFeedsResponseAPI = InfiniteResponse<{ feeds: TFeedDetailAPI[] }>;
+type GetSubscribeFeedsResponse = InfiniteResponse<{ feeds: TFeedDetail[] }>;
+
+export async function requestGetSubscribeFeeds({ nextCursor }: GetSubscribeFeedsPayload) {
+  return await axios.get<GetSubscribeFeedsResponseAPI>(`/feeds?fetchingType=SUBSCRIBE&limit=12&nextCursor=${nextCursor}`).then(
+    ({ data: { feeds, nextCursor } }) =>
+      ({
+        nextCursor,
+        feeds: feeds.map(({ id, styleIds, ...feed }) => ({
+          feedId: id,
+          styleIds: styleIds.map(({ id }) => id),
+          accountId: feed.username,
+          ...feed,
+        })),
+      }) as GetSubscribeFeedsResponse
   );
 }

--- a/src/services/member.ts
+++ b/src/services/member.ts
@@ -1,4 +1,6 @@
 import { axios } from '@Libs/axios';
+import { TSubscriber, TSubscriberAPI } from '@Types/model';
+import { InfiniteResponse } from '@Types/response';
 
 type UpdateUserDetailsPayload = { accountId: string; profileImageId: number };
 type UpdateUserDetailsResponse = '';
@@ -17,4 +19,26 @@ export async function requestSubscribeMember({ toMemberId, wouldSubscribe }: Req
   }
 
   return await axios.delete<RequestSubscribeMemberResponse>(`/subscribe/${toMemberId}`, {});
+}
+
+type RequestGetSubscribersPayload = { nextCursor: number };
+type RequestGetSubscribersResponseAPI = InfiniteResponse<{ subscribers: TSubscriberAPI[]; totalSubscribers: number }>;
+type RequestGetSubscribersResponse = InfiniteResponse<{ subscribers: TSubscriber[]; totalSubscribers: number }>;
+
+export async function requestGetSubscribers({ nextCursor }: RequestGetSubscribersPayload) {
+  return await axios.get<RequestGetSubscribersResponseAPI>(`/subscribe/subscribers?nextCursor=${nextCursor}`).then(
+    ({ data: { subscribers, nextCursor, totalSubscribers } }) =>
+      ({
+        subscribers: subscribers.map(
+          ({ id, username, profileImageURL }) =>
+            ({
+              userId: id,
+              accountId: username,
+              profileImageURL,
+            }) as TSubscriber
+        ),
+        nextCursor,
+        totalSubscribers,
+      }) as RequestGetSubscribersResponse
+  );
 }

--- a/src/types/model.ts
+++ b/src/types/model.ts
@@ -81,10 +81,74 @@ export interface TFAPArchivingFeedAPI extends TFeed {
   createdAt: Date;
 }
 
-export interface TAllFashionFeedAPI extends TFeed {}
+export interface TAllFashionFeedAPI extends TFeed {
+  username: string;
+}
 export interface TAllFashionFeed extends Omit<TFeed, 'id' | 'styleIds'> {
   feedId: number;
   styleIds: number[];
+}
+
+interface TFeedDetailBase extends Omit<TFeed, 'id' | 'styleIds' | 'username'> {
+  accountId: string;
+  profileImageURL: string;
+
+  feedId: number;
+  styleIds: number[];
+
+  isFAPFeed: boolean;
+  isSubscribed: boolean;
+  isBookmarked: boolean;
+  isMine: boolean;
+
+  votedAt?: Date;
+}
+
+interface TFeedDetailBaseAPI extends TFeed {
+  username: string;
+  profileImageURL: string;
+
+  isFAPFeed: boolean;
+  isSubscribed: boolean;
+  isBookmarked: boolean;
+  isMine: boolean;
+
+  votedAt?: Date;
+}
+
+interface TFeedDetailMine extends TFeedDetailBase, TFeedAdittionalDetail {
+  isMine: true;
+  isSubscribed: never;
+}
+
+interface TFeedDetailMineAPI extends TFeedDetailBaseAPI, TFeedAdittionalDetail {
+  isMine: true;
+  isSubscribed: never;
+}
+
+export interface TFeedAdittionalDetail {
+  fadeInCount: number;
+  bookmarkCount: number;
+  reportCount: number;
+}
+
+interface TFeedDetailVote extends TFeedDetailBase {
+  votedAt: Date;
+}
+
+interface TFeedDetailVoteAPI extends TFeedDetailBaseAPI {
+  votedAt: Date;
+}
+
+export type TFeedDetail = TFeedDetailBase | TFeedDetailMine | TFeedDetailVote;
+export type TFeedDetailAPI = TFeedDetailBaseAPI | TFeedDetailMineAPI | TFeedDetailVoteAPI;
+
+export function isTFeedDetailMine(feedDetail: TFeedDetail): feedDetail is TFeedDetailMine {
+  return feedDetail.isMine;
+}
+
+export function isTFeedDetailVote(feedDetail: TFeedDetail): feedDetail is TFeedDetailVote {
+  return feedDetail.votedAt !== undefined;
 }
 
 /**

--- a/src/types/model.ts
+++ b/src/types/model.ts
@@ -151,6 +151,18 @@ export function isTFeedDetailVote(feedDetail: TFeedDetail): feedDetail is TFeedD
   return feedDetail.votedAt !== undefined;
 }
 
+export interface TSubscriberAPI {
+  id: number;
+  username: string;
+  profileImageURL: string;
+}
+
+export interface TSubscriber {
+  userId: number;
+  accountId: string;
+  profileImageURL: string;
+}
+
 /**
  * TFeed
  *  TVoteCandidate


### PR DESCRIPTION
### 관련된 이슈 번호를 기입해주세요.
> `close #이슈번호` 와 같은 형식으로 작성해주세요.

- close  #144  #147 

### 어떤 부분이 변경됐나요?
> 어떤 부분을 변경했는지, 무슨 이유로 코드를 변경했는지 설명해주세요.

**사진 상세 화면을 작성하고 연동했어요.**
- 모달로 띄우다 보니까 무한 스크롤을 어떻게 동작하게 만들지가 ... 좀 애매하더라고요
- 그래서 일단 포함된 피드의 해당 인덱스로 이동하는 것만 만들었습니다.
- 사진 상세로 연결되는 기존 로직들 교체했습니다.

**구독 탭과 관련된 API를 연동했어요.**
- 구독 목록 조회 API를 연동했어요.
- 구독 피드 조회 API를 연동했어요.

### 추가 정보 (선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.

- 무한 스크롤 훅이 좀 말썽이어서 ;; 나중에 수정 필요함.
