### PR TITLE
투표 내역 API 연동(미해결)

### DIFF
--- a/src/__mock__/handlers.ts
+++ b/src/__mock__/handlers.ts
@@ -11,6 +11,7 @@ import {
   generateDummyFeedDetail,
   generateDummyFeedUserDetail,
   generateDummySubscribersWithPagination,
+  generateDummyVoteHistory,
   generateTVoteCandidateDummyData,
 } from './utils';
 
@@ -303,5 +304,20 @@ export const handlers = [
     await delay(NETWORK_DELAY);
 
     return HttpResponse.json({ details: generateDummyFeedUserDetail() }, { status: HttpStatusCode.Ok });
+  }),
+
+  http.get(`${BASE_URL}/vote/history`, async ({ request }) => {
+    await delay(NETWORK_DELAY);
+
+    const { searchParams } = new URL(request.url);
+    const scrollType = searchParams.get('scrollType')!;
+    const selectedDate = searchParams.get('selectedDate')!;
+    const limit = searchParams.get('limit')!;
+
+    const direction = scrollType === '0' ? 'down' : scrollType === '1' ? 'up' : 'both';
+
+    const result = generateDummyVoteHistory({ limit: +limit, baseDate: selectedDate, direction });
+
+    return HttpResponse.json(result, { status: HttpStatusCode.Ok });
   }),
 ];

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -58,6 +58,7 @@ export function Button({
   );
 }
 
+/** TODO: 서브 페이지일 때의 위치도 넣기 */
 export function BackButton({ className, onClick }: { className?: string; onClick: () => void }) {
   return (
     <Button variants="ghost" size="icon" className={cn('absolute left-3 top-1/2 -translate-y-1/2', className)} onClick={onClick}>

--- a/src/pages/Root/mypage/feed/page.tsx
+++ b/src/pages/Root/mypage/feed/page.tsx
@@ -1,15 +1,20 @@
-import { BackButton } from '@Components/ui/button';
 import { ProfileDetails } from '@Components/ProfileDetails';
+import { Button } from '@Components/ui/button';
 import { useHeader } from '@Hooks/useHeader';
+import { MdChevronLeft } from 'react-icons/md';
 import { useNavigate } from 'react-router-dom';
 
 export default function Page() {
+  const navigate = useNavigate();
+
   useHeader({
     title: '내 피드',
-    leftSlot: () => <BackButton className="right-0" onClick={() => navigate('/mypage', { replace: true })} />,
+    leftSlot: () => (
+      <Button variants="ghost" size="icon" onClick={() => navigate('/mypage', { replace: true })}>
+        <MdChevronLeft className="size-6" />
+      </Button>
+    ),
   });
-
-  const navigate = useNavigate();
 
   return (
     <div className="flex h-full flex-col">

--- a/src/pages/Root/mypage/voteHistory/page.tsx
+++ b/src/pages/Root/mypage/voteHistory/page.tsx
@@ -10,7 +10,7 @@ import { useInfiniteQuery } from '@tanstack/react-query';
 import { TVoteHistoryItem } from '@Types/model';
 import { cn } from '@Utils/index';
 import { format } from 'date-fns';
-import { motion } from 'framer-motion';
+import { AnimatePresence, motion } from 'framer-motion';
 import { useEffect, useState } from 'react';
 import { MdChevronLeft } from 'react-icons/md';
 import { useNavigate } from 'react-router-dom';
@@ -65,7 +65,9 @@ export default function Page() {
       </div>
 
       <div className="flex-1 space-y-[3.75rem] overflow-y-scroll p-5">
-        {data?.pages.map((page) => [page.feeds.slice(0, 10), page.feeds.slice(11, 21), page.feeds.slice(21, 31)].map((feeds) => <VoteHistoryItem feeds={feeds} />))}
+        {data?.pages.map((page) =>
+          [page.feeds.slice(0, 10), page.feeds.slice(11, 21), page.feeds.slice(21, 31)].map((feeds) => <VoteHistoryItem isFadeInMode={isFadeInMode} feeds={feeds} />)
+        )}
         <p className="text-detail text-gray-700">모든 투표 내역을 불러왔습니다.</p>
       </div>
     </div>
@@ -99,16 +101,22 @@ function FadeInModeToggleButton({ isFadeInMode, onToggle }: { isFadeInMode: bool
   );
 }
 
-function VoteHistoryItem({ feeds }: { feeds: TVoteHistoryItem[] }) {
+function VoteHistoryItem({ isFadeInMode, feeds }: { isFadeInMode: boolean; feeds: TVoteHistoryItem[] }) {
   const votedAtLabel = feeds.at(0) && format(feeds.at(0).votedAt, 'yyyy년 M월 d일');
 
   return (
     <section className="space-y-2">
       <h6 className="text-h6 font-semibold">{votedAtLabel}</h6>
       <Grid id="feedList" cols={5}>
-        {feeds.map((feed, index) => (
-          <FeedItem key={`feed-item-${feed.feedId}`} {...feed} feeds={feeds} index={index} />
-        ))}
+        <AnimatePresence>
+          {feeds.map((feed, index) => {
+            if (isFadeInMode) {
+              return feed.voteType === 'FADE_IN' && <FeedItem key={`feed-item-${feed.feedId}`} {...feed} feeds={feeds} index={index} />;
+            } else {
+              return <FeedItem key={`feed-item-${feed.feedId}`} {...feed} feeds={feeds} index={index} />;
+            }
+          })}
+        </AnimatePresence>
       </Grid>
     </section>
   );
@@ -128,8 +136,14 @@ function FeedItem({ feeds, index, ...feed }: FeedItemProps) {
   };
 
   return (
-    <div key={`item-${feed.feedId}`} className="group aspect-[3/4] w-full cursor-pointer overflow-hidden rounded-lg" onClick={handleClick}>
+    <motion.div
+      layout
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      exit={{ opacity: 0 }}
+      className="group aspect-[3/4] w-full cursor-pointer overflow-hidden rounded-lg"
+      onClick={handleClick}>
       <Image src={feed.feedImageURL} className="h-full w-full transition-transform group-hover:scale-105" />
-    </div>
+    </motion.div>
   );
 }

--- a/src/services/vote.ts
+++ b/src/services/vote.ts
@@ -1,8 +1,9 @@
 import { axios } from '@Libs/axios';
-import { TFeed, TVoteCandidate, TVoteResult } from '@Types/model';
+import { TFeed, TVoteCandidateAPI, TVoteHistoryItem, TVoteHistoryItemAPI, TVoteResult } from '@Types/model';
+import { VoteInfiniteResponse } from '@Types/response';
 
 type GetVoteCandidatesAPIResponse = { feeds: TFeed[] };
-type GetVoteCandidatesResponse = { voteCandidates: TVoteCandidate[] };
+type GetVoteCandidatesResponse = { voteCandidates: TVoteCandidateAPI[] };
 
 export async function requestGetVoteCandidates() {
   return await axios.get<GetVoteCandidatesAPIResponse>('/vote/candidates').then(
@@ -20,4 +21,22 @@ type SendVoteResultPayload = TVoteResult[];
 
 export async function requestSendVoteResult(voteItems: SendVoteResultPayload) {
   return await axios.post('/vote/candidates', { voteItems });
+}
+
+type GetVoteHistoryPayload = { nextCursor: string; scrollType: string };
+type GetVoteHistoryResponseAPI = VoteInfiniteResponse<{ feeds: TVoteHistoryItemAPI[] }>;
+type GetVoteHistoryResponse = VoteInfiniteResponse<{ feeds: TVoteHistoryItem[] }>;
+
+export async function requestGetVoteHistory({ scrollType, nextCursor }: GetVoteHistoryPayload) {
+  return await axios.get<GetVoteHistoryResponseAPI>(`/vote/history?limit=3&nextCursor=${nextCursor}&scrollType=${scrollType}`).then(
+    ({ data: { feeds, ...rest } }) =>
+      ({
+        ...rest,
+        feeds: feeds.map(({ styleIds, username, ...feed }) => ({
+          ...feed,
+          accountId: username,
+          styleIds: styleIds.map(({ id }) => id),
+        })),
+      }) as GetVoteHistoryResponse
+  );
 }

--- a/src/types/model.ts
+++ b/src/types/model.ts
@@ -187,3 +187,16 @@ export interface TFeedUserDetail {
  *    TVoteCandidateCard
  *  TFAPArchivingFeed
  */
+
+export interface TVoteHistoryItemAPI extends Omit<TFeedDetailBaseAPI, 'imageURL' | 'id'> {
+  feedId: number;
+  feedImageURL: string;
+  voteType: 'FADE_IN' | 'FADE_OUT';
+  votedAt: Date;
+}
+
+export interface TVoteHistoryItem extends Omit<TFeedDetailBase, 'imageURL'> {
+  feedImageURL: string;
+  voteType: 'FADE_IN' | 'FADE_OUT';
+  votedAt: Date;
+}

--- a/src/types/response.ts
+++ b/src/types/response.ts
@@ -1,3 +1,11 @@
 export type InfiniteResponse<T> = {
   nextCursor: number;
 } & T;
+
+export type VoteInfiniteResponse<T> = {
+  nextCursorToUpScroll: string;
+  nextCursorToDownScroll: string;
+  direction: string;
+  isLastCursorToUpScroll: boolean;
+  isLastCursorToDownScroll: boolean;
+} & T;


### PR DESCRIPTION
### 관련된 이슈 번호를 기입해주세요.
> `close #이슈번호` 와 같은 형식으로 작성해주세요.

- close #153 

### 어떤 부분이 변경됐나요?
> 어떤 부분을 변경했는지, 무슨 이유로 코드를 변경했는지 설명해주세요.

**투표 내역 API 모킹을 작성했어요.**
- 투표 내역 테스트를 위한 API 모킹을 작성했어요.

**투표 내역 관련 모델 타입을 작성했어요.**
- 투표 내역 관련은 기존 Feed와는 다르게 응답값이 와서 해당 부분을 위해 모델을 작성했어요.
- 무한 스크롤 형식도 기존과 다르게 양방향이라 이를 위해 응답 모델도 작성했어요.

**투표 내역 애니메이션을 적용했어요.**
- Slide In만 나오는 애니메이션을 적용했어요.

![GIF 2024-07-28 오후 8-23-27](https://github.com/user-attachments/assets/467bef31-cf06-413b-8d10-4eacc39d41f7)

### 추가 정보 (선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.

- 투표 내역 API를 고민하기엔 시간이 꽤 걸릴 것 같은데, 마감까지 좀 얼마 안 남아서 다른 것 먼저 쳐내려고 합니다.
- 완성된 부분은 수료 기준의 있어라이팅을 위해 머지합니다.
