### PR TITLE
로그인 성공 이후 Authorization Header 추가

### DIFF
--- a/src/libs/axios.ts
+++ b/src/libs/axios.ts
@@ -24,4 +24,12 @@ axiosInstance.interceptors.response.use(
   }
 );
 
-export { axiosInstance as axios };
+function setAuthorizationHeader({ accessToken }: { accessToken: string }) {
+  axiosInstance.defaults.headers.common.Authorization = `Bearer ${accessToken}`;
+}
+
+function clearAuthorizationHeader() {
+  axiosInstance.defaults.headers.common.Authorization = ``;
+}
+
+export { axiosInstance as axios, setAuthorizationHeader, clearAuthorizationHeader };

--- a/src/pages/Auth/SignOut.tsx
+++ b/src/pages/Auth/SignOut.tsx
@@ -1,4 +1,5 @@
 import { useAuthActions } from '@Hooks/auth';
+import { clearAuthorizationHeader } from '@Libs/axios';
 import { requestSignOut } from '@Services/auth';
 import { useEffect } from 'react';
 import { Navigate } from 'react-router-dom';
@@ -12,6 +13,7 @@ export default function SignOut() {
 
   useEffect(() => {
     signOut();
+    clearAuthorizationHeader();
   }, []);
 
   return <Navigate to="/" replace />;

--- a/src/pages/Root/page.tsx
+++ b/src/pages/Root/page.tsx
@@ -1,5 +1,6 @@
 import { useAuthActions, useIsAuthenticated } from '@Hooks/auth';
 import { useToastActions } from '@Hooks/toast';
+import { setAuthorizationHeader } from '@Libs/axios';
 import { requestRefreshToken } from '@Services/auth';
 import { LoaderResponseStatus } from '@Types/loaderResponse';
 import { clearSearchParams, createErrorLoaderResponse, createSuccessLoaderResponse, tryCatcher } from '@Utils/index';
@@ -41,6 +42,7 @@ export default function Page() {
     if (shouldSignIn) {
       signIn(payload!);
       clearSearchParams();
+      setAuthorizationHeader({ accessToken: payload.accessToken });
     }
 
     navigate('/vote-fap');


### PR DESCRIPTION
### 관련된 이슈 번호를 기입해주세요.
> `close #이슈번호` 와 같은 형식으로 작성해주세요.

- close #169 

### 어떤 부분이 변경됐나요?
> 어떤 부분을 변경했는지, 무슨 이유로 코드를 변경했는지 설명해주세요.

**Authorization Header 관련 로직을 작성했어요.**
- 받은 accessToken을 Authorization에 넣는 setAuthorizationHeader()를 작성했어요.
- Authorization를 초기화 하는 clearAuthorizationHeader()를 작성했어요.
- 로그인과 로그아웃 시 각각의 함수를 호출해요.

### 추가 정보 (선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.

- 회원탈퇴 할 때도 필요할 것 같긴 한데, 그 부분은 회원탈퇴 진행하면서 진행하겠습니다.
