### PR TITLE
투표 선택지 커버 FADE OUT 블링킹 이슈

### DIFF
--- a/src/components/ToastProvider.tsx
+++ b/src/components/ToastProvider.tsx
@@ -15,7 +15,7 @@ export function ToastProvider() {
         ))}
       </AnimatePresence>
 
-      <RadixToast.Viewport className="absolute bottom-0 left-0 flex w-full flex-col gap-3 px-5 py-5" />
+      <RadixToast.Viewport className="absolute bottom-[4rem] left-0 flex w-full flex-col gap-3 px-5 py-5" />
     </RadixToast.Provider>
   );
 }

--- a/src/layouts/AppLayout.tsx
+++ b/src/layouts/AppLayout.tsx
@@ -12,7 +12,7 @@ export default function AppLayout() {
         <Header />
       </FlexibleLayout.Header>
 
-      <FlexibleLayout.Content className="relative">
+      <FlexibleLayout.Content>
         <Suspense fallback={<>페이지 로딩 중!</>}>
           <Outlet />
         </Suspense>

--- a/src/pages/Root/voteFAP/components/VotingView.tsx
+++ b/src/pages/Root/voteFAP/components/VotingView.tsx
@@ -1,7 +1,6 @@
 import { BookmarkButton } from '@Components/BookmarkButton';
 import { ReportButton } from '@Components/ReportButton';
 import { SubscribeButton } from '@Components/SubscribeButton';
-import { Image } from '@Components/ui/image';
 import { useToastActions } from '@Hooks/toast';
 import { requestGetVoteCandidates, requestSendVoteResult } from '@Services/vote';
 import { SwipeDirection, useVotingStore } from '@Stores/vote';
@@ -314,8 +313,10 @@ function VoteCandidateCard({ feedId, imageURL, isCurrentCard }: VoteCandidateCar
       )}
 
       <motion.div style={{ opacity: computedOpacity }} className="absolute inset-0 grid place-items-center rounded-lg bg-purple-500">
-        {isLeftBoundary && <FadeOutCover />}
-        {isRightBoundary && <FadeInCover />}
+        <AnimatePresence>
+          {isLeftBoundary && <FadeOutCover />}
+          {isRightBoundary && <FadeInCover />}
+        </AnimatePresence>
       </motion.div>
 
       <DragController
@@ -329,11 +330,11 @@ function VoteCandidateCard({ feedId, imageURL, isCurrentCard }: VoteCandidateCar
 }
 
 function FadeOutCover() {
-  return <Image src={swipeFadeOutImage} className="h-[3.2725rem] w-[21.875rem]" />;
+  return <motion.img initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }} src={swipeFadeOutImage} className="h-[3.2725rem] w-[21.875rem]" />;
 }
 
 function FadeInCover() {
-  return <Image src={swipeFadeInImage} className="h-[3.2725rem] w-[16.7719rem]" />;
+  return <motion.img initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }} src={swipeFadeInImage} className="h-[3.2725rem] w-[16.7719rem]" />;
 }
 
 type DragControllerProps = {
@@ -357,8 +358,8 @@ function DragController({ x, onDragStart, onDragEnd, onDragOffBoundary }: DragCo
       dragTransition={{ bounceStiffness: 1000, bounceDamping: 50 }}
       onDragStart={onDragStart}
       onDrag={(_, { offset: { x } }) => {
-        const isLeftDirection = x < 0 && x < offsetBoundary * -1;
-        const isRightDirection = x > 0 && x > offsetBoundary;
+        const isLeftDirection = x < 0; // && x < offsetBoundary * -1;
+        const isRightDirection = x > 0; // && x > offsetBoundary;
         const hasNoDirection = !isLeftDirection && !isRightDirection;
 
         isLeftDirection && onDragOffBoundary('left');


### PR DESCRIPTION
### 관련된 이슈 번호를 기입해주세요.
> `close #이슈번호` 와 같은 형식으로 작성해주세요.

- close #179 

### 어떤 부분이 변경됐나요?
> 어떤 부분을 변경했는지, 무슨 이유로 코드를 변경했는지 설명해주세요.

**ToastProvider Rendering 로직을 변경했어요.**
- AppLayout의 Content에 Relative를 넣음으로써 위치를 조절했었는데,, 그렇게 하면 이상하게 VotingView의 화면전환 애니메이션이 안 먹더라고요(!)
- 원인을 아무리 찾아봐도 모르겠어서 일단 Padding으로 해결봤습니다.

**선택지 커버 이미지를 img으로 바꿨어요.**
- Image 컴포넌트는 prefetch가 완료되어야 실제 데이터를 불러오는 형태입니다.
- 그 전에는 bg-gray-200을 보여주는데,, 이게 문제가 되어 블링킹처럼 보였던 것.
- transparent하게 두는 게 맞긴 한 것 같은데 그럼 기존 로직을 다 변경해야 해서 일단 img으로 바꿨습니다!

### 추가 정보 (선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.

- 해당 없음
