### PR TITLE
FA:P 아카이브 캘린더 오늘 이후 Greyed 

### DIFF
--- a/src/__mock__/_utils.ts
+++ b/src/__mock__/_utils.ts
@@ -133,7 +133,13 @@ export const createVoteCandidateDTODummies = (count: number): TVoteCandidateDTO[
 export const createFAPArchivingFeedDTODummies = (baseDate: Date): TFAPArchivingFeedDTO[] => {
   const year = baseDate.getFullYear();
   const month = baseDate.getMonth();
-  const daysInMonth = new Date(year, month + 1, 0).getDate();
+  let daysInMonth = 0;
+
+  if (year === new Date().getFullYear() && month === new Date().getMonth()) {
+    daysInMonth = new Date().getDate() - 1;
+  } else {
+    daysInMonth = new Date(year, month + 1, 0).getDate();
+  }
 
   const dummies: TFAPArchivingFeedDTO[] = [];
   for (let day = 1; day <= daysInMonth; day++) {

--- a/src/pages/Root/archive/components/FAPArchivingView.tsx
+++ b/src/pages/Root/archive/components/FAPArchivingView.tsx
@@ -120,6 +120,9 @@ function FAPFeeds({ calenderDate }: FAPFeedsProps) {
   const daysInMonth = getDaysInMonth(calenderDate);
   const firstDayOfWeek = format(startOfDay(calenderDate), 'e');
 
+  const isThisMonth = calenderDate === format(new Date(), 'yyyy-MM');
+  const todayDay = new Date().getDate();
+
   const feeds = data?.feeds;
 
   return (
@@ -131,6 +134,8 @@ function FAPFeeds({ calenderDate }: FAPFeedsProps) {
             feeds={feeds}
             feed={feeds?.find((feed) => getDate(feed.fapSelectedAt) === index + 1)}
             day={index + 1}
+            todayDay={todayDay}
+            isThisMonth={isThisMonth}
             firstDayOfWeek={firstDayOfWeek}
           />
         ))}
@@ -144,12 +149,16 @@ interface TDayItem {
   feeds: TFAPArchivingFeed[] | undefined;
   feed: TFAPArchivingFeed | undefined;
   firstDayOfWeek: string;
+  todayDay: number;
+  isThisMonth: boolean;
 }
 
 type DayItemProps = TDayItem;
 
-function DayItem({ day, feed, feeds, firstDayOfWeek }: DayItemProps) {
+function DayItem({ day, feed, feeds, firstDayOfWeek, isThisMonth, todayDay }: DayItemProps) {
   const { showModal } = useModalActions();
+  const isTodayDay = isThisMonth && day == todayDay;
+  const isOverTodayDay = isThisMonth && day > todayDay;
 
   const handleClick = async () => {
     if (!feed) {
@@ -168,8 +177,20 @@ function DayItem({ day, feed, feeds, firstDayOfWeek }: DayItemProps) {
       className="flex h-full w-full flex-col"
       style={{ gridColumnStart: day === 1 ? firstDayOfWeek : undefined }}
       onClick={handleClick}>
-      <span className="ml-1">{day}</span>
-      <div className={cn('group h-full w-full overflow-hidden rounded-lg bg-gray-200', { ['cursor-pointer']: !!feed, ['animate-pulse']: !feeds })}>
+      <span
+        className={cn('relative ml-1 w-fit', {
+          ['text-white']: isTodayDay,
+          ['text-gray-400']: isOverTodayDay,
+        })}>
+        {isTodayDay && <div className="absolute left-1/2 top-1/2 -z-10 size-5 -translate-x-1/2 -translate-y-1/2 rounded-full bg-purple-500" />}
+        {day}
+      </span>
+      <div
+        className={cn('group h-full w-full overflow-hidden rounded-lg bg-gray-200', {
+          ['cursor-pointer']: !!feed,
+          ['animate-pulse']: !feeds,
+          ['bg-gray-50']: isTodayDay || !isTodayDay,
+        })}>
         {feed && <Image src={feed.imageURL} className="transition-transform group-hover:scale-105" />}
       </div>
     </motion.div>


### PR DESCRIPTION
### 관련된 이슈 번호를 기입해주세요.
> `close #이슈번호` 와 같은 형식으로 작성해주세요.

- close #204 

### 어떤 부분이 변경됐나요?
> 어떤 부분을 변경했는지, 무슨 이유로 코드를 변경했는지 설명해주세요.

**FA:P 아카이브 조회 API 모킹 로직을 변경했어요.**
- baseDate가 이번 달일 때, 이번 달 이전의 데이터를 보내줍니다.

**FA:P 아카이브 캘린더 UI를 수정했어요.**
- 오늘 일자에 마크표시가 생겼습니다.
- 오늘 이후 일자에 대해서 Greyed 처리하였습니다.

![image](https://github.com/user-attachments/assets/52fe166e-efb7-49a3-a547-8b305a5192e6)

### 추가 정보 (선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.

- 해당 없음
