### PR TITLE
투표 정보 저장 로직 수정

### DIFF
--- a/src/components/BookmarkButton.tsx
+++ b/src/components/BookmarkButton.tsx
@@ -11,13 +11,14 @@ import { VscLoading } from 'react-icons/vsc';
 interface TBookmarkButton {
   feedId: number;
   defaultBookmarkStatus: boolean;
+  onToggle?: (value: boolean) => void;
   size?: 'default' | 'lg';
   shadow?: boolean;
 }
 
 type BookmarkButtonProps = TBookmarkButton;
 
-export function BookmarkButton({ feedId, defaultBookmarkStatus, size = 'default', shadow = false }: BookmarkButtonProps) {
+export function BookmarkButton({ feedId, defaultBookmarkStatus, size = 'default', shadow = false, onToggle }: BookmarkButtonProps) {
   const [isBookmarked, setIsBookmarked] = useState(defaultBookmarkStatus);
   const { showToast } = useToastActions();
 
@@ -41,6 +42,7 @@ export function BookmarkButton({ feedId, defaultBookmarkStatus, size = 'default'
       {
         onSuccess() {
           queryClient.invalidateQueries({ queryKey: ['user', 'me', 'bookmark'] });
+          onToggle && onToggle(!defaultBookmarkStatus);
         },
         onError() {
           setIsBookmarked((prev) => !prev);

--- a/src/pages/Root/voteFAP/components/VotingView.tsx
+++ b/src/pages/Root/voteFAP/components/VotingView.tsx
@@ -3,6 +3,7 @@ import { ReportButton } from '@Components/ReportButton';
 import { SubscribeButton } from '@Components/SubscribeButton';
 import { Image } from '@Components/ui/image';
 import { useToastActions } from '@Hooks/toast';
+import { queryClient } from '@Libs/queryclient';
 import { requestGetVoteCandidates, requestSendVoteResult } from '@Services/vote';
 import { SwipeDirection, TLocalVoteData, useVotingStore } from '@Stores/vote';
 import { useMutation, useQuery } from '@tanstack/react-query';
@@ -14,7 +15,6 @@ import { format } from 'date-fns';
 import { AnimatePresence, motion, MotionValue, useMotionValue, useTransform, Variants } from 'framer-motion';
 import { useEffect, useLayoutEffect, useState, useTransition } from 'react';
 import { RandomAvatar } from './RandomAvatar';
-import { queryClient } from '@Libs/queryclient';
 
 const voteFadeInImage = '/assets/fade_in_btn.png';
 const voteFadeOutImage = '/assets/fade_out_btn.png';
@@ -50,13 +50,15 @@ const outputOpacity = [1, 0, 1];
 
 type VotingViewType = 'loading' | 'voting' | 'submitting';
 
+/** TODO: 최초 local정보 불러오기 분리 */
+
 export function VotingView({ onSubmitDone }: { onSubmitDone: () => void }) {
   const { showToast } = useToastActions();
 
   const cycleId = useVotingStore((state) => state.cycleId);
   const isVotingInProgress = useVotingStore((state) => state.isVotingInProgress);
-  const setVotingCountToday = useVotingStore((state) => state.setVotingCountToday);
   const setHasVotedToday = useVotingStore((state) => state.setHasVotedToday);
+  const setVoteResults = useVotingStore((state) => state.setVoteResults);
   const setVotingProgress = useVotingStore((state) => state.setVotingProgress);
   const setIsVotingInProgress = useVotingStore((state) => state.setIsVotingInProgress);
   const setViewCards = useVotingStore((state) => state.setViewCards);
@@ -65,35 +67,32 @@ export function VotingView({ onSubmitDone }: { onSubmitDone: () => void }) {
   const [viewId, setViewId] = useState<VotingViewType>(isVotingInProgress ? 'voting' : 'loading');
 
   const localVoteData = localStorage.getItem('FADE_VOTE_DATA');
-  const isLocalVoteDataValid =
-    localVoteData !== null && (JSON.parse(localVoteData || `{"lastVotedAt":"undefined"}`) as TLocalVoteData).lastVotedAt === format(new Date(), 'yyyy-MM-dd');
 
   const isLoadingView = viewId === 'loading';
   const isVotingView = viewId === 'voting';
   const isSubmittingView = viewId === 'submitting';
 
-  // TODO: localStorage 정보에 오늘 거 있으면 그걸로, 없으면 패칭
-
   const { data: response } = useQuery({
     queryKey: ['vote', 'candidates', cycleId],
     queryFn: () => requestGetVoteCandidates(),
-    enabled: viewId === 'loading' && !isLocalVoteDataValid,
+    enabled: viewId === 'loading' && localVoteData === null,
   });
 
   useEffect(() => {
-    if (!isLocalVoteDataValid) {
+    if (localVoteData === null) {
       return;
     }
 
-    const { isVotingInProgress, viewCards, votingCountToday, votingProgress } = JSON.parse(localVoteData) as TLocalVoteData;
+    const { viewCards, voteResults } = JSON.parse(localVoteData) as TLocalVoteData;
 
     setViewCards(viewCards);
-    setIsVotingInProgress(isVotingInProgress);
-    setVotingCountToday(votingCountToday);
-    setVotingProgress(votingProgress);
-    setViewId('voting');
+    setVoteResults(voteResults);
+
     setIsVotingInProgress(true);
-  }, [isLocalVoteDataValid]);
+    setVotingProgress(voteResults.length);
+
+    setViewId('voting');
+  }, [localVoteData]);
 
   useEffect(() => {
     if (isVotingInProgress || !response) {
@@ -107,19 +106,9 @@ export function VotingView({ onSubmitDone }: { onSubmitDone: () => void }) {
     if (hasNoVoteCandidate) {
       showToast({ type: 'basic', title: '오늘 투표할 페이더들의 사진이 없습니다.' });
 
-      localStorage.setItem(
-        'FADE_VOTE_DATA',
-        JSON.stringify({
-          hasVotedToday: true,
-          lastVotedAt: format(new Date(), 'yyyy-MM-dd'),
-          isVotingInProgress: false,
-          viewCards: [],
-          votingCountToday: 0,
-          votingProgress: 0,
-        } as TLocalVoteData)
-      );
+      localStorage.setItem('FADE_LAST_VOTED_AT', format(new Date(), 'yyyy-MM-dd'));
+      localStorage.removeItem('FADE_VOTE_DATA');
 
-      setHasVotedToday(true);
       setIsVotingInProgress(false);
       handleSubmitDone();
       return;
@@ -147,22 +136,24 @@ export function VotingView({ onSubmitDone }: { onSubmitDone: () => void }) {
     localStorage.setItem(
       'FADE_VOTE_DATA',
       JSON.stringify({
-        lastVotedAt: format(new Date(), 'yyyy-MM-dd'),
-        isVotingInProgress: true,
         viewCards: voteCandidateCards,
-        votingCountToday: 0,
-        votingProgress: 1,
+        voteResults: [],
       } as TLocalVoteData)
     );
   }, [response]);
 
   const handleVoteFinish = () => {
+    localStorage.removeItem('FADE_VOTE_DATA');
+
     setViewId('submitting');
     setIsVotingInProgress(false);
   };
 
   const handleSubmitDone = () => {
     queryClient.invalidateQueries({ queryKey: ['user', 'me', 'voteHistory'] });
+    localStorage.setItem('FADE_LAST_VOTED_AT', format(new Date(), 'yyyy-MM-dd'));
+
+    setHasVotedToday(true);
 
     generateNewCycleId();
     onSubmitDone();
@@ -279,28 +270,17 @@ function LoadingVoteCandidatesView() {
 
 function AwaitedVotingView({ onVoteFinish }: { onVoteFinish: () => void }) {
   const clearVotingProgress = useVotingStore((state) => state.clearVotingProgress);
-  const setHasVotedToday = useVotingStore((state) => state.setHasVotedToday);
-  const hasVotedToday = useVotingStore((state) => state.hasVotedToday);
   const viewCards = useVotingStore((state) => state.viewCards);
 
   useLayoutEffect(() => {
     if (viewCards.length === 0) {
-      !hasVotedToday && setHasVotedToday(true);
-      // localStorage.setItem(
-      //   'FADE_VOTE_DATA',
-      //   JSON.stringify({
-      //     lastVotedAt: format(new Date(), 'yyyy-MM-dd'),
-      //     isVotingInProgress: false,
-      //     viewCards: [],
-      //     votingCountToday: 0,
-      //     votingProgress: 0,
-      //   } as TLocalVoteData)
-      // );
-      // localStorage.setItem('FADE_LAST_VOTED_AT', format(new Date(), 'yyyy-MM-dd'));
-
       clearVotingProgress();
       onVoteFinish();
+      return;
     }
+
+    const voteData = JSON.parse(localStorage.getItem('FADE_VOTE_DATA')!) as TLocalVoteData;
+    localStorage.setItem('FADE_VOTE_DATA', JSON.stringify({ ...voteData, viewCards }));
   }, [viewCards]);
 
   return (

--- a/src/pages/Root/voteFAP/components/VotingView.tsx
+++ b/src/pages/Root/voteFAP/components/VotingView.tsx
@@ -441,11 +441,21 @@ function UserDetailCard() {
   const isSubscribed = useVotingStore(({ viewCards }) => viewCards.at(-1)?.isSubscribed || false);
   const memberId = useVotingStore(({ viewCards }) => viewCards.at(-1)?.memberId || -1);
 
+  const handleSubscribeToggle = (value: boolean) => {
+    const voteData = JSON.parse(localStorage.getItem('FADE_VOTE_DATA')!) as TLocalVoteData;
+    const matchedItem = voteData.viewCards.at(-1)!; // 구독은 마지막 아이템에만 할 수 있음
+
+    localStorage.setItem(
+      'FADE_VOTE_DATA',
+      JSON.stringify({ ...voteData, viewCards: [...voteData.viewCards.slice(0, -1), { ...matchedItem, isSubscribed: value }] } as TLocalVoteData)
+    );
+  };
+
   return (
     <div className="flex flex-row items-center justify-center gap-3 rounded-lg bg-white px-3 py-2 shadow-bento">
       <RandomAvatar />
       <AnimatedUsername name={anonName} />
-      <SubscribeButton initialSubscribedStatus={isSubscribed} userId={memberId} onToggle={(value) => console.log(value)} />
+      <SubscribeButton initialSubscribedStatus={isSubscribed} userId={memberId} onToggle={handleSubscribeToggle} />
     </div>
   );
 }

--- a/src/pages/Root/voteFAP/components/VotingView.tsx
+++ b/src/pages/Root/voteFAP/components/VotingView.tsx
@@ -497,6 +497,16 @@ function VotingTools() {
   const feedId = useVotingStore(({ viewCards }) => viewCards.at(-1)?.feedId || -1);
   const isBookmarked = useVotingStore(({ viewCards }) => viewCards.at(-1)?.isBookmarked || false);
 
+  const handleBookmarkToggle = (value: boolean) => {
+    const voteData = JSON.parse(localStorage.getItem('FADE_VOTE_DATA')!) as TLocalVoteData;
+    const matchedItem = voteData.viewCards.at(-1)!; // 구독은 마지막 아이템에만 할 수 있음
+
+    localStorage.setItem(
+      'FADE_VOTE_DATA',
+      JSON.stringify({ ...voteData, viewCards: [...voteData.viewCards.slice(0, -1), { ...matchedItem, isBookmarked: value }] } as TLocalVoteData)
+    );
+  };
+
   return (
     <div className="flex w-full flex-col gap-3">
       <UserDetailCard />
@@ -504,7 +514,7 @@ function VotingTools() {
       <div className="flex flex-row gap-3">
         <VoteButton type="fadeOut" onClick={() => handleSelect('left')} />
         <VoteButton type="fadeIn" onClick={() => handleSelect('right')} />
-        <BookmarkButton feedId={feedId} defaultBookmarkStatus={isBookmarked} shadow />
+        <BookmarkButton feedId={feedId} defaultBookmarkStatus={isBookmarked} shadow onToggle={handleBookmarkToggle} />
       </div>
     </div>
   );

--- a/src/stores/vote.ts
+++ b/src/stores/vote.ts
@@ -14,78 +14,104 @@ interface VotingState {
   votingProgress: number; // 1부터 시작, 1: 1을 투표할 차례라는 뜻
   swipeDirection: SwipeDirection; // 애니메이션을 위한 스와이프 방향
 
-  generateNewCycleId: () => void;
-  setViewCards: (viewCards: TVoteCandidateCard[]) => void;
   updateVoteResult: (voteResult: TVoteResult) => void;
+  setVoteResults: (voteResults: TVoteResult[]) => void;
   clearVoteResults: () => void;
-  setHasVotedToday: (hasVoted: boolean) => void;
-  setIsVotingInProgress: (isInProgress: boolean) => void;
+
   setVotingCountToday: (votingCountToday: number) => void;
   addVotingCountToday: () => void;
+
   setVotingProgress: (votingProgress: number) => void;
   addVotingProgress: () => void;
   clearVotingProgress: () => void;
+
+  setViewCards: (viewCards: TVoteCandidateCard[]) => void;
   setSwipeDirection: (swipeDirection: SwipeDirection) => void;
 
+  setHasVotedToday: (hasVoted: boolean) => void;
+  setIsVotingInProgress: (isInProgress: boolean) => void;
+
+  generateNewCycleId: () => void;
   handleSelect: (swipeDirection: SwipeDirection) => void;
 }
 
+/**
+ * 투표를 하다가 중간에 나갔다 들어오면 유지할 수 있도록
+ * LocalStorage에 필요한 투표 정보를 담음
+ * 해당 정보는 투표를 시작할 때 생성되며, 진행될 때 업데이트 되고, 끝나면 삭제된다.
+ */
+
 export interface TLocalVoteData {
-  lastVotedAt: string;
-  isVotingInProgress: boolean;
-  votingCountToday: number;
-  votingProgress: number;
   viewCards: TVoteCandidateCard[];
-  hasVotedToday: boolean;
+  voteResults: TVoteResult[];
 }
 
 const loadSavedVotingData = () => {
+  const lastVotedAt = localStorage.getItem('FADE_LAST_VOTED_AT');
   const savedVoteData = localStorage.getItem('FADE_VOTE_DATA');
 
+  const hasVotedToday = lastVotedAt === null ? false : lastVotedAt === format(new Date(), 'yyyy-MM-dd');
+  const votingCountToday = lastVotedAt === null || hasVotedToday ? Number(localStorage.getItem('FADE_VOTE_COUNT') || 0) : 0; // 오늘 투표를 진행하지 않았지만(10번) 투표를 하고 있었을 수 있음.
+
   if (savedVoteData === null) {
-    return {};
+    return { hasVotedToday, votingCountToday };
   }
 
-  const { lastVotedAt, ...voteData } = JSON.parse(savedVoteData) as TLocalVoteData;
+  const voteData = JSON.parse(savedVoteData) as TLocalVoteData;
 
-  if (lastVotedAt !== format(new Date(), 'yyyy-MM-dd')) {
-    localStorage.removeItem('FADE_VOTE_DATA');
-    return {};
-  }
-
-  return voteData;
+  return {
+    hasVotedToday,
+    isVotingInProgress: true,
+    votingProgress: voteData.voteResults.length,
+    votingCountToday,
+    ...voteData,
+  };
 };
+
+/** TODO: 나중에 votingProgress를 voteResuts로 계산하기 */
 
 export const useVotingStore = create<VotingState>((set, get) => ({
   cycleId: generateRandomId(),
   viewCards: [],
   voteResults: [],
-  hasVotedToday: false,
   isVotingInProgress: false,
-  votingCountToday: 0,
   votingProgress: 1,
   swipeDirection: 'right',
   ...loadSavedVotingData(),
 
-  generateNewCycleId: () => set({ cycleId: generateRandomId() }),
-  setViewCards: (viewCards) => set({ viewCards }),
   updateVoteResult: (voteResult) => set(({ voteResults }) => ({ voteResults: [...voteResults, voteResult] })),
+  setVoteResults: (voteResults) => set({ voteResults }),
   clearVoteResults: () => set({ voteResults: [] }),
-  setHasVotedToday: (hasVotedToday) => set({ hasVotedToday }),
-  setIsVotingInProgress: (isVotingInProgress) => set({ isVotingInProgress }),
+
   setVotingCountToday: (votingCountToday) => set({ votingCountToday }),
   addVotingCountToday: () => set(({ votingCountToday }) => ({ votingCountToday: votingCountToday + 1 })),
+
   setVotingProgress: (votingProgress) => set({ votingProgress }),
   addVotingProgress: () => set(({ votingProgress }) => ({ votingProgress: votingProgress + 1 })),
   clearVotingProgress: () => set({ votingProgress: 1 }),
+
+  setViewCards: (viewCards) => set({ viewCards }),
   setSwipeDirection: (swipeDirection) => set({ swipeDirection }),
 
+  setHasVotedToday: (hasVotedToday) => set({ hasVotedToday }),
+  setIsVotingInProgress: (isVotingInProgress) => set({ isVotingInProgress }),
+
+  generateNewCycleId: () => set({ cycleId: generateRandomId() }),
+
   handleSelect: (swipeDirection) => {
-    const { viewCards, setViewCards, setSwipeDirection, addVotingCountToday, addVotingProgress, updateVoteResult } = get();
+    const { viewCards, votingCountToday, setViewCards, setSwipeDirection, addVotingCountToday, addVotingProgress, updateVoteResult } = get();
     const currentViewCard = viewCards.at(-1);
 
     if (currentViewCard) {
-      updateVoteResult({ feedId: currentViewCard.feedId, voteType: swipeDirection === 'left' ? 'FADE_OUT' : 'FADE_IN' });
+      const newVoteResult: TVoteResult = {
+        feedId: currentViewCard.feedId,
+        voteType: swipeDirection === 'left' ? 'FADE_OUT' : 'FADE_IN',
+      };
+
+      const voteData = JSON.parse(localStorage.getItem('FADE_VOTE_DATA')!) as TLocalVoteData;
+      localStorage.setItem('FADE_VOTE_DATA', JSON.stringify({ ...voteData, voteResults: [...voteData.voteResults, newVoteResult] } as TLocalVoteData));
+
+      updateVoteResult(newVoteResult);
     }
 
     setViewCards(viewCards.slice(0, -1));
@@ -93,5 +119,7 @@ export const useVotingStore = create<VotingState>((set, get) => ({
 
     addVotingProgress();
     addVotingCountToday();
+
+    localStorage.setItem('FADE_VOTE_COUNT', String(votingCountToday + 1));
   },
 }));


### PR DESCRIPTION
### 관련된 이슈 번호를 기입해주세요.
> `close #이슈번호` 와 같은 형식으로 작성해주세요.

- close #239 

### 어떤 부분이 변경됐나요?
> 어떤 부분을 변경했는지, 무슨 이유로 코드를 변경했는지 설명해주세요.

**투표 정보를 저장하는 로직을 수정했어요.**
- 저장하는 투표 정보를 변경하였습니다.
  - 마지막으로 투표한 날짜(last_voted_at)
  - 진행하고 있는 투표 정보(vote_data)
  - 투표한 횟수(vote_count)
- 투표 정보는 투표를 진행할 때만 생깁니다.
  - 최초로 투표 정보를 불러오면 생성
  - 투표 전송이 완료되면 삭제
- 투표한 횟수는 마지막으로 투표한 날짜의 존재 여부 및 오늘인지에 따라 반영합니다.
  - last_voted_at 미존재: 최초 10번 투표를 하진 않았는데, 투표를 진행 중
  - last_voted_at 존재: 오늘이면 반영하고 없으면 초기화

### 추가 정보 (선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.

- 해당 없음
