### PR TITLE
투표 후보군 목록 미존재 시 토스트 이슈 & S3 이미지 쿼리 파람 추가

### DIFF
--- a/src/components/ui/image.tsx
+++ b/src/components/ui/image.tsx
@@ -18,7 +18,7 @@ export function Image({ children, src, className, alt, size = 'cover', local = f
     <div className={cn('relative grid h-full w-full place-content-center', className)}>
       <img
         src={src}
-        srcSet={local ? createSrcSet(src) : src}
+        srcSet={local ? createSrcSet(src) : `${src}?w=720&q=10`}
         alt={alt}
         className={cn('pointer-events-none absolute inset-0 block h-full w-full', {
           ['[display:none]']: isError,

--- a/src/pages/Root/voteFAP/components/ReadyToVoteView.tsx
+++ b/src/pages/Root/voteFAP/components/ReadyToVoteView.tsx
@@ -3,11 +3,11 @@ import { Image } from '@Components/ui/image';
 import { useModalActions } from '@Hooks/modal';
 import { HowToVoteModal } from './HowToVoteModal';
 
-export function ReadyToVoteView({ onStartClick }: { onStartClick: () => void }) {
+export function ReadyToVoteView({ onVoteStart }: { onVoteStart: () => void }) {
   return (
     <div className="flex h-full flex-col justify-between gap-5">
       <ReadyToVoteCover />
-      <ReadyToVoteTools onStartClick={onStartClick} />
+      <ReadyToVoteTools onVoteStart={onVoteStart} />
     </div>
   );
 }
@@ -34,10 +34,10 @@ function HowToVoteButton() {
   );
 }
 
-function ReadyToVoteTools({ onStartClick }: { onStartClick: () => void }) {
+function ReadyToVoteTools({ onVoteStart }: { onVoteStart: () => void }) {
   return (
     <div className="flex w-full flex-col gap-3">
-      <StartVoteButton onClick={onStartClick} />
+      <StartVoteButton onClick={onVoteStart} />
       <HowToVoteButton />
     </div>
   );

--- a/src/pages/Root/voteFAP/components/RestartVotingView.tsx
+++ b/src/pages/Root/voteFAP/components/RestartVotingView.tsx
@@ -2,11 +2,11 @@ import { Button } from '@Components/ui/button';
 import { Image } from '@Components/ui/image';
 import { useNavigate } from 'react-router-dom';
 
-export function RestartVotingView({ onRestartVote }: { onRestartVote: () => void }) {
+export function RestartVotingView({ onVoteRestart }: { onVoteRestart: () => void }) {
   return (
     <div className="flex h-full flex-col justify-between gap-5">
       <RestartVotingCover />
-      <RestartVotingTools onRestartVote={onRestartVote} />
+      <RestartVotingTools onVoteRestart={onVoteRestart} />
     </div>
   );
 }
@@ -19,12 +19,12 @@ function RestartVotingCover() {
   );
 }
 
-function RestartVotingTools({ onRestartVote }: { onRestartVote: () => void }) {
+function RestartVotingTools({ onVoteRestart }: { onVoteRestart: () => void }) {
   const navigate = useNavigate();
 
   return (
     <div className="flex w-full flex-col gap-3">
-      <Button className="text-xl" onClick={onRestartVote}>
+      <Button className="text-xl" onClick={onVoteRestart}>
         투표 다시하기
       </Button>
 

--- a/src/pages/Root/voteFAP/components/VoteController.tsx
+++ b/src/pages/Root/voteFAP/components/VoteController.tsx
@@ -20,39 +20,53 @@ const enum VoteViewType {
 }
 
 export function VoteController() {
+  const generateNewCycleId = useVotingStore((state) => state.generateNewCycleId);
   const isVotingInProgress = useVotingStore((state) => state.isVotingInProgress);
+
   const [viewId, setViewId] = useState<VoteViewType>(isVotingInProgress ? VoteViewType.VOTING : VoteViewType.BEFORE_VOTING);
 
   const isBeforeVoting = viewId === VoteViewType.BEFORE_VOTING;
   const isVoting = viewId === VoteViewType.VOTING;
   const isAfterVoting = viewId === VoteViewType.AFTER_VOTING;
 
+  const handleVoteStart = () => {
+    generateNewCycleId();
+    setViewId(VoteViewType.VOTING);
+  };
+
+  const handleVoteFlowDone = () => {
+    setViewId(VoteViewType.AFTER_VOTING);
+  };
+
+  const handleVoteRestart = () => {
+    generateNewCycleId();
+    setViewId(VoteViewType.VOTING);
+  };
+
   return (
-    <>
-      <div className="h-full">
-        <BackgroundEllipse />
+    <div className="h-full">
+      <BackgroundEllipse />
 
-        <AnimatePresence mode="wait">
-          {isBeforeVoting && (
-            <motion.div {...baseAnimateProps} key="view-1" variants={viewVariants} className="h-full">
-              <ReadyToVoteView onStartClick={() => setViewId(VoteViewType.VOTING)} />
-            </motion.div>
-          )}
+      <AnimatePresence mode="wait">
+        {isBeforeVoting && (
+          <motion.div {...baseAnimateProps} key="view-1" variants={viewVariants} className="h-full">
+            <ReadyToVoteView onVoteStart={handleVoteStart} />
+          </motion.div>
+        )}
 
-          {isVoting && (
-            <motion.div {...baseAnimateProps} key="view-2" variants={viewVariants} className="h-full">
-              <VotingView onSubmitDone={() => setViewId(VoteViewType.AFTER_VOTING)} />
-            </motion.div>
-          )}
+        {isVoting && (
+          <motion.div {...baseAnimateProps} key="view-2" variants={viewVariants} className="h-full">
+            <VotingView onVoteFlowDone={handleVoteFlowDone} />
+          </motion.div>
+        )}
 
-          {isAfterVoting && (
-            <motion.div {...baseAnimateProps} key="view-3" variants={viewVariants} className="h-full">
-              <RestartVotingView onRestartVote={() => setViewId(VoteViewType.VOTING)} />
-            </motion.div>
-          )}
-        </AnimatePresence>
-      </div>
-    </>
+        {isAfterVoting && (
+          <motion.div {...baseAnimateProps} key="view-3" variants={viewVariants} className="h-full">
+            <RestartVotingView onVoteRestart={handleVoteRestart} />
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </div>
   );
 }
 

--- a/src/pages/Root/voteFAP/page.tsx
+++ b/src/pages/Root/voteFAP/page.tsx
@@ -1,14 +1,14 @@
 import { ShowNotificationButton } from '@Components/ShowNotificationButton';
+import { Button } from '@Components/ui/button';
 import { useModalActions } from '@Hooks/modal';
 import { useHeader } from '@Hooks/useHeader';
 import { FlexibleLayout } from '@Layouts/FlexibleLayout';
+import { useAuthStore } from '@Stores/auth';
 import { useVotingStore } from '@Stores/vote';
 import { AnimatePresence, motion } from 'framer-motion';
 import { MdInfoOutline } from 'react-icons/md';
 import { VoteController } from './components/VoteController';
 import { VotePolicyBottomSheet } from './components/VotePolicyBottomSheet';
-import { Button } from '@Components/ui/button';
-import { useAuthStore } from '@Stores/auth';
 
 export default function Page() {
   useHeader({


### PR DESCRIPTION
### 관련된 이슈 번호를 기입해주세요.
> `close #이슈번호` 와 같은 형식으로 작성해주세요.

- close #247 

### 어떤 부분이 변경됐나요?
> 어떤 부분을 변경했는지, 무슨 이유로 코드를 변경했는지 설명해주세요.

**투표 후보군 목록을 불러오는 로직을 변경했어요.**
- 기존의 투표 진행 정보를 불러오는 로직과 새로운 목록을 패칭하는 로직이 서로 충돌을 일으켜서 해당 이슈가 생겼습니다.
- 로딩 상태를 VotingView로 빼고, 투표 및 제출 화면은 VoteFlowHandler로 처리하였습니다.
- VotingView에서는 isDataAwaited 상태를 두어서, 로컬 투표 진행 정보 및 새로운 투표 후보군 목록을 패칭했을 시 True로 변경합니다.
- isDataAwaited에 따라 로딩 상태를 보여줄지, VoteFlowHandler를 보여줄지 결정합니다.
- `isVotingInProgress`: 투표 진행 정보 존재할 때부터 ~ 투표 결과 전송 완료시까지를 나타내는 상태
- `cycleId`: React Query에서 새로운 패칭 데이터를 불러오기 위한 상태(staleTime으로 해결되지 않았음)
- 이제... 진짜 될 겁니다.. (아마)

**S3 이미지 쿼리 파람을 추가했어요.**
- 임시로 Width를 720, q를 10으로 진행했습니다.

### 추가 정보 (선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.

- 해당 없음
