### PR TITLE
서비스 둘러보기 기능 추가

### DIFF
--- a/src/components/MockingButton.tsx
+++ b/src/components/MockingButton.tsx
@@ -1,8 +1,9 @@
 import * as Popover from '@radix-ui/react-popover';
 import { useVotingStore } from '@Stores/vote';
+import { removeLocalData } from '@Utils/index';
+import { useEffect, useState } from 'react';
 import { MdSettings } from 'react-icons/md';
 import { Button } from './ui/button';
-import { useEffect, useState } from 'react';
 
 export function MockingButton() {
   const setHasVotedToday = useVotingStore((state) => state.setHasVotedToday);
@@ -16,6 +17,14 @@ export function MockingButton() {
       // MSW 중지
       const { worker } = await import('@/__mock__/instance');
       worker.stop();
+
+      // 로컬 데이터 삭제
+      removeLocalData('_fert');
+      removeLocalData('FADE_VOTE_COUNT');
+      removeLocalData('FADE_LAST_VOTED_AT');
+      removeLocalData('FADE_LAST_FAP_DATE');
+      removeLocalData('FADE_VOTE_DATA');
+      removeLocalData('FADE_SEARCH_HISTORY');
 
       location.reload();
     };
@@ -51,7 +60,7 @@ export function MockingButton() {
               </Button>
             </li>
             <li className="w-full">
-              <Button variants="ghost" className="w-full" onClick={() => localStorage.removeItem('FADE_LAST_FAP_DATE')}>
+              <Button variants="ghost" className="w-full" onClick={() => removeLocalData('FADE_LAST_FAP_DATE')}>
                 Reset yesterday's FA:P alerts
               </Button>
             </li>

--- a/src/components/MockingButton.tsx
+++ b/src/components/MockingButton.tsx
@@ -1,66 +1,50 @@
 import * as Popover from '@radix-ui/react-popover';
 import { useVotingStore } from '@Stores/vote';
-import { cn } from '@Utils/index';
-import { useRef, useState } from 'react';
 import { MdSettings } from 'react-icons/md';
 import { Button } from './ui/button';
-
-const LOCALSTORAGE_KEY = 'FADE_API_MOCKING_ENABLED' as const;
+import { useEffect, useState } from 'react';
 
 export function MockingButton() {
-  const mockButtonRef = useRef<HTMLButtonElement>(null);
   const setHasVotedToday = useVotingStore((state) => state.setHasVotedToday);
+  const [isMockingEnabled, setIsMockingEnabled] = useState(false);
 
-  const [isMockEnabled, setIsMockEnabled] = useState(() => {
-    return (localStorage.getItem(LOCALSTORAGE_KEY) as 'true' | 'false' | undefined) === 'true' ? true : false;
-  });
+  useEffect(() => {
+    const handleMockingStart = () => setIsMockingEnabled(true);
+    const handleMockingEnd = async () => {
+      setIsMockingEnabled(false);
 
-  const handleClick = async () => {
-    if (mockButtonRef.current === null) {
-      return;
-    }
+      // MSW 중지
+      const { worker } = await import('@/__mock__/instance');
+      worker.stop();
 
-    const { worker } = await import('../__mock__/instance');
+      location.reload();
+    };
 
-    isMockEnabled && worker.stop();
-    !isMockEnabled && worker.start({ onUnhandledRequest: 'bypass' });
+    window.addEventListener('mockingStart', handleMockingStart);
+    window.addEventListener('mockingEnd', handleMockingEnd);
 
-    setIsMockEnabled((prev) => !prev);
-    localStorage.setItem(LOCALSTORAGE_KEY, String(!isMockEnabled));
-  };
+    return () => {
+      window.removeEventListener('mockingStart', handleMockingStart);
+      window.removeEventListener('mockingEnd', handleMockingEnd);
+    };
+  }, []);
+
+  if (!isMockingEnabled) {
+    return null;
+  }
 
   return (
     <Popover.Root>
       <Popover.Trigger asChild>
-        <Button
-          variants="outline"
-          interactive="onlyScale"
-          size="icon"
-          className={cn('pointer-events-auto border border-gray-200 bg-white shadow-2xl', {
-            ['border-red-400 bg-red-300']: isMockEnabled,
-          })}>
+        <Button variants="outline" interactive="onlyScale" size="icon" className="pointer-events-auto border border-red-400 bg-red-300 shadow-2xl">
           <MdSettings />
         </Button>
       </Popover.Trigger>
       <Popover.Portal>
         <Popover.Content className="translate-y-2 rounded-xl border border-gray-200 bg-white p-5 shadow-2xl">
           <Popover.Arrow className="fill-white stroke-gray-200" />
+          <p className="mb-3 whitespace-pre-line text-center text-detail">{`서비스 둘러보기 시에만\n나타나는 테스트 버튼입니다`}</p>
           <ul className="flex flex-col">
-            <li className="w-full">
-              <Button
-                ref={mockButtonRef}
-                aria-checked={(localStorage.getItem('FADE_API_MOCKING_ENABLED') as 'true' | 'false' | undefined) || 'false'}
-                variants="ghost"
-                className={cn('w-full', { ['text-pink-400']: isMockEnabled })}
-                onClick={handleClick}>
-                {isMockEnabled ? 'Disable' : 'Enable'} API Mocking
-              </Button>
-            </li>
-            <li className="w-full">
-              <Button variants="ghost" className="w-full" onClick={() => location.reload()}>
-                Page Reload
-              </Button>
-            </li>
             <li className="w-full">
               <Button variants="ghost" className="w-full" onClick={() => setHasVotedToday(true)}>
                 Bypass the vote check today

--- a/src/hooks/auth.ts
+++ b/src/hooks/auth.ts
@@ -4,6 +4,7 @@ import { requestRefreshToken } from '@Services/auth';
 import { useAuthStore } from '@Stores/auth';
 import { AuthTokens } from '@Types/model';
 import { ServiceErrorResponse } from '@Types/serviceError';
+import { removeLocalData, saveLocalData } from '@Utils/index';
 import { isAxiosError } from 'axios';
 import { useCallback, useMemo } from 'react';
 
@@ -27,7 +28,7 @@ export const useAuthActions = () => {
       setTokens({ accessToken, refreshToken });
       setAuthFromToken({ accessToken });
       setAuthorizationHeader({ accessToken });
-      localStorage.setItem('_fert', btoa(refreshToken));
+      saveLocalData('_fert', btoa(refreshToken));
     },
     [setTokens, setAuthFromToken]
   );
@@ -35,7 +36,7 @@ export const useAuthActions = () => {
   const signOut = useCallback(() => {
     resetAuth();
     clearAuthorizationHeader();
-    localStorage.removeItem('_fert');
+    removeLocalData('_fert');
   }, [resetAuth]);
 
   const doRefreshToken = useCallback(async () => {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,25 +1,5 @@
 import ReactDOM from 'react-dom/client';
+import App from './App.tsx';
 import './index.css';
 
-export async function enableMocking(enabled: boolean = false) {
-  // if (import.meta.env.PROD || !enabled) {
-  if (!enabled) {
-    return;
-  }
-
-  const { worker } = await import('./__mock__/instance.ts');
-
-  return worker.start({
-    onUnhandledRequest: 'bypass',
-  });
-}
-
-const LOCALSTORAGE_KEY = 'FADE_API_MOCKING_ENABLED' as const;
-
-const isMockEnabled = (localStorage.getItem(LOCALSTORAGE_KEY) as 'true' | 'false' | undefined) === 'true' ? true : false;
-
-enableMocking(isMockEnabled).then(() => {
-  import('./App.tsx').then((App) => {
-    ReactDOM.createRoot(document.getElementById('root')!).render(<App.default />);
-  });
-});
+ReactDOM.createRoot(document.getElementById('root')!).render(<App />);

--- a/src/pages/Root/archive/components/FAPArchivingView.tsx
+++ b/src/pages/Root/archive/components/FAPArchivingView.tsx
@@ -6,7 +6,7 @@ import { useModalActions } from '@Hooks/modal';
 import { requestFAPArchiving } from '@Services/feed';
 import { useQuery } from '@tanstack/react-query';
 import { TFAPArchivingFeed } from '@Types/model';
-import { cn, isBetweenDate } from '@Utils/index';
+import { cn, isBetweenDate, loadLocalData, saveLocalData } from '@Utils/index';
 import { addMonths, format, getDate, getDaysInMonth, getWeeksInMonth, isSameMonth, isSameYear, startOfDay, subDays, subMonths } from 'date-fns';
 import { AnimatePresence, motion } from 'framer-motion';
 import { useEffect, useState } from 'react';
@@ -132,7 +132,7 @@ function FAPFeeds({ calenderDate }: FAPFeedsProps) {
       return;
     }
 
-    const savedLastFAPDate = localStorage.getItem('FADE_LAST_FAP_DATE');
+    const savedLastFAPDate = loadLocalData('FADE_LAST_FAP_DATE');
     const lastFAPDate = format(feeds.at(-1)!.fapSelectedAt, 'yyyy-MM-dd');
 
     if (savedLastFAPDate === lastFAPDate) {
@@ -151,7 +151,7 @@ function FAPFeeds({ calenderDate }: FAPFeedsProps) {
       props: { feed: feeds.at(-1)! } as LastFAPModalProps,
     });
 
-    localStorage.setItem('FADE_LAST_FAP_DATE', yesterday);
+    saveLocalData('FADE_LAST_FAP_DATE', yesterday);
   }, [isSuccess]);
 
   return (

--- a/src/pages/Root/archive/components/SearchAccountView.tsx
+++ b/src/pages/Root/archive/components/SearchAccountView.tsx
@@ -6,6 +6,7 @@ import { requestSearchUser } from '@Services/member';
 import { DefaultModalProps } from '@Stores/modal';
 import { useQuery } from '@tanstack/react-query';
 import { TMatchedUser } from '@Types/model';
+import { loadLocalData, saveLocalData } from '@Utils/index';
 import { AnimatePresence, motion } from 'framer-motion';
 import { useEffect, useRef, useState } from 'react';
 import { MdCancel, MdClose, MdSearch, MdWarning } from 'react-icons/md';
@@ -21,7 +22,7 @@ export function SearchAccountView({ onClose }: DefaultModalProps) {
   const [isDebouncePending, debouncedUsername] = useDebounce(targetUsername, 350);
   const [results, setResults] = useState<TMatchedUser[]>([]);
 
-  const [searchHistory, setSearchHistory] = useState<TMatchedUser[]>(JSON.parse(localStorage.getItem('FADE_SEARCH_HISTORY') || '[]') as TMatchedUser[]);
+  const [searchHistory, setSearchHistory] = useState<TMatchedUser[]>(JSON.parse(loadLocalData('FADE_SEARCH_HISTORY') || '[]') as TMatchedUser[]);
 
   const { data, isPending: isQueryPending } = useQuery({
     queryKey: ['search', 'user', debouncedUsername],
@@ -39,12 +40,12 @@ export function SearchAccountView({ onClose }: DefaultModalProps) {
     const hasAlreadyUser = searchHistory.find(({ id }) => id === userDetail.id);
 
     if (hasAlreadyUser) {
-      localStorage.setItem('FADE_SEARCH_HISTORY', JSON.stringify([userDetail, ...searchHistory.filter(({ id }) => id !== userDetail.id)]));
+      saveLocalData('FADE_SEARCH_HISTORY', JSON.stringify([userDetail, ...searchHistory.filter(({ id }) => id !== userDetail.id)]));
     } else {
       if (searchHistory.length > 4) {
-        localStorage.setItem('FADE_SEARCH_HISTORY', JSON.stringify([userDetail, ...searchHistory.slice(0, -1)]));
+        saveLocalData('FADE_SEARCH_HISTORY', JSON.stringify([userDetail, ...searchHistory.slice(0, -1)]));
       } else {
-        localStorage.setItem('FADE_SEARCH_HISTORY', JSON.stringify([userDetail, ...searchHistory]));
+        saveLocalData('FADE_SEARCH_HISTORY', JSON.stringify([userDetail, ...searchHistory]));
       }
     }
 
@@ -56,7 +57,7 @@ export function SearchAccountView({ onClose }: DefaultModalProps) {
     const matchedItem = searchHistory.find(({ id }) => id === userId)!;
     const newHistory: TMatchedUser[] = [matchedItem, ...searchHistory.filter(({ id }) => id !== userId)];
 
-    localStorage.setItem('FADE_SEARCH_HISTORY', JSON.stringify(newHistory));
+    saveLocalData('FADE_SEARCH_HISTORY', JSON.stringify(newHistory));
     setSearchHistory(newHistory);
 
     navigate('/user', { state: { userId } });
@@ -66,7 +67,7 @@ export function SearchAccountView({ onClose }: DefaultModalProps) {
   const handleHistoryUserItemDelete = (userId: number) => {
     const newHistory: TMatchedUser[] = [...searchHistory.filter(({ id }) => id !== userId)];
 
-    localStorage.setItem('FADE_SEARCH_HISTORY', JSON.stringify(newHistory));
+    saveLocalData('FADE_SEARCH_HISTORY', JSON.stringify(newHistory));
     setSearchHistory(newHistory);
   };
 

--- a/src/pages/Root/login/components/ExploreServiceButton.tsx
+++ b/src/pages/Root/login/components/ExploreServiceButton.tsx
@@ -1,9 +1,9 @@
 import { Button } from '@Components/ui/button';
 import { useModalActions } from '@Hooks/modal';
-import { ExploreServiceModal } from './ExploreServiceModal';
-import { useNavigate } from 'react-router-dom';
 import { useState } from 'react';
 import { VscLoading } from 'react-icons/vsc';
+import { useNavigate } from 'react-router-dom';
+import { ExploreServiceModal } from './ExploreServiceModal';
 
 const { VITE_KAKAO_API_KEY: apiKey, VITE_KAKAO_REDIRECT_URL: redirectURL } = import.meta.env;
 const kakaoLoginURL = `https://kauth.kakao.com/oauth/authorize?client_id=${apiKey}&redirect_uri=${redirectURL}&response_type=code`;
@@ -35,6 +35,7 @@ export function ExploreServiceButton() {
     await worker.start({ onUnhandledRequest: 'bypass' });
 
     window.dispatchEvent(new CustomEvent('mockingStart'));
+    document.querySelector('html')!.dataset.mockingEnabled = 'true';
 
     return navigate('/auth/callback/kakao?code=test', { replace: true });
   };

--- a/src/pages/Root/login/components/ExploreServiceButton.tsx
+++ b/src/pages/Root/login/components/ExploreServiceButton.tsx
@@ -1,0 +1,48 @@
+import { Button } from '@Components/ui/button';
+import { useModalActions } from '@Hooks/modal';
+import { ExploreServiceModal } from './ExploreServiceModal';
+import { useNavigate } from 'react-router-dom';
+import { useState } from 'react';
+import { VscLoading } from 'react-icons/vsc';
+
+const { VITE_KAKAO_API_KEY: apiKey, VITE_KAKAO_REDIRECT_URL: redirectURL } = import.meta.env;
+const kakaoLoginURL = `https://kauth.kakao.com/oauth/authorize?client_id=${apiKey}&redirect_uri=${redirectURL}&response_type=code`;
+
+export function ExploreServiceButton() {
+  const navigate = useNavigate();
+  const { showModal } = useModalActions();
+
+  const [isMockingPending, setIsMockingPending] = useState(false);
+
+  const handleClick = async () => {
+    const isMockingEnabled = await showModal<boolean>({ type: 'component', Component: ExploreServiceModal });
+
+    // 취소
+    if (isMockingEnabled == undefined) {
+      return;
+    }
+
+    // 10초 로그인
+    if (!isMockingEnabled) {
+      location.replace(kakaoLoginURL);
+      return;
+    }
+
+    setIsMockingPending(true);
+
+    // MSW 작동
+    const { worker } = await import('@/__mock__/instance');
+    await worker.start({ onUnhandledRequest: 'bypass' });
+
+    window.dispatchEvent(new CustomEvent('mockingStart'));
+
+    return navigate('/auth/callback/kakao?code=test', { replace: true });
+  };
+
+  return (
+    <Button variants="outline" onClick={handleClick} disabled={isMockingPending}>
+      {isMockingPending && <VscLoading className="mr-1 animate-spin" />}
+      서비스 둘러보기
+    </Button>
+  );
+}

--- a/src/pages/Root/login/components/ExploreServiceModal.tsx
+++ b/src/pages/Root/login/components/ExploreServiceModal.tsx
@@ -1,0 +1,36 @@
+import { Button } from '@Components/ui/button';
+import { DefaultModalProps } from '@Stores/modal';
+import { forwardRef } from 'react';
+
+export const ExploreServiceModal = forwardRef<HTMLDivElement, DefaultModalProps>(({ onClose }: DefaultModalProps, ref) => {
+  return (
+    <div ref={ref}>
+      <header className="relative px-5 py-4">
+        <p className="text-center text-2xl font-semibold">서비스 둘러보기</p>
+      </header>
+
+      <div className="space-y-2 p-5">
+        <p>안녕하세요, FADE입니다.</p>
+        <p>
+          서비스 둘러보기는 실제 환경이 아닌 <strong>API Mocking 환경</strong>에서 동작하며, 이로 인해 실제 환경과 다소 다를 수 있음을 알려드려요.
+        </p>
+        <p>
+          참고로 서비스 가입에 필요한 시간은 <strong>단 10초</strong>입니다. 지금 바로 시작해보세요 :)
+        </p>
+        <div>
+          <p className="text-gray-600">* API Mocking 환경</p>
+          <p className="ml-[1rem] text-gray-600">: 실제 데이터가 아닌 테스트 데이터가 반환됩니다.</p>
+        </div>
+      </div>
+
+      <div className="flex flex-row gap-4 p-5">
+        <Button className="flex-1" variants="ghost" onClick={() => onClose(false)}>
+          10초 만에 가입하기
+        </Button>
+        <Button className="flex-1" onClick={() => onClose(true)}>
+          계속해서 둘러보기
+        </Button>
+      </div>
+    </div>
+  );
+});

--- a/src/pages/Root/login/page.tsx
+++ b/src/pages/Root/login/page.tsx
@@ -1,6 +1,6 @@
 import { FadeLogo } from '@Components/FadeLogo';
-import { Link } from 'react-router-dom';
 import { Carousel } from './components/Carousel';
+import { ExploreServiceButton } from './components/ExploreServiceButton';
 import { KakaoLoginButton } from './components/KakaoLoginButton';
 
 export default function Page() {
@@ -17,9 +17,7 @@ export default function Page() {
       <div className="flex flex-[0.8] items-center">
         <div className="flex flex-col gap-3">
           <KakaoLoginButton />
-          <Link to="/auth/callback/kakao?code=test" className="rounded-lg border bg-gray-50 p-2 text-center">
-            테스트 로그인(API 모킹용)
-          </Link>
+          <ExploreServiceButton />
         </div>
       </div>
     </section>

--- a/src/pages/Root/mypage/page.tsx
+++ b/src/pages/Root/mypage/page.tsx
@@ -158,7 +158,10 @@ function LogoutButton() {
   const handleClick = async () => {
     const result = await confirm({ title: '로그아웃 하시겠습니까?', description: '언제든 다시 로그인 할 수 있어요.' });
 
-    result && navigate('/auth/signout', { replace: true });
+    if (result) {
+      window.dispatchEvent(new CustomEvent('mockingEnd'));
+      navigate('/auth/signout', { replace: true });
+    }
   };
 
   return (

--- a/src/pages/Root/page.tsx
+++ b/src/pages/Root/page.tsx
@@ -5,7 +5,7 @@ import { requestRefreshToken } from '@Services/auth';
 import { useSuspenseQuery } from '@tanstack/react-query';
 import { AuthTokens } from '@Types/model';
 import { ServiceErrorResponse } from '@Types/serviceError';
-import { getPayloadFromJWT } from '@Utils/index';
+import { getPayloadFromJWT, loadLocalData } from '@Utils/index';
 import { isAxiosError } from 'axios';
 import { useEffect } from 'react';
 import { Navigate, useNavigate } from 'react-router-dom';
@@ -16,7 +16,7 @@ import { Navigate, useNavigate } from 'react-router-dom';
 
 export default function Page() {
   const isAuthenticated = useIsAuthenticated();
-  const savedRefreshToken = atob(localStorage.getItem('_fert') || ''); // 암호화된 RT를 특정하지 못하도록 키를 줄임, FADE Encrypted Refresh Token
+  const savedRefreshToken = atob(loadLocalData('_fert') || ''); // 암호화된 RT를 특정하지 못하도록 키를 줄임, FADE Encrypted Refresh Token
 
   if (isAuthenticated) {
     return <Navigate to="/vote-fap" />;

--- a/src/stores/vote.ts
+++ b/src/stores/vote.ts
@@ -1,5 +1,5 @@
 import { TVoteCandidateCard, TVoteResult } from '@Types/model';
-import { generateRandomId } from '@Utils/index';
+import { generateRandomId, loadLocalData, saveLocalData } from '@Utils/index';
 import { format } from 'date-fns';
 import { create } from 'zustand';
 
@@ -47,11 +47,11 @@ export interface TLocalVoteData {
 }
 
 const loadSavedVotingData = () => {
-  const lastVotedAt = localStorage.getItem('FADE_LAST_VOTED_AT');
-  const savedVoteData = localStorage.getItem('FADE_VOTE_DATA');
+  const lastVotedAt = loadLocalData('FADE_LAST_VOTED_AT');
+  const savedVoteData = loadLocalData('FADE_VOTE_DATA');
 
   const hasVotedToday = lastVotedAt === null ? false : lastVotedAt === format(new Date(), 'yyyy-MM-dd');
-  const votingCountToday = lastVotedAt === null || hasVotedToday ? Number(localStorage.getItem('FADE_VOTE_COUNT') || 0) : 0; // 오늘 투표를 진행하지 않았지만(10번) 투표를 하고 있었을 수 있음.
+  const votingCountToday = lastVotedAt === null || hasVotedToday ? Number(loadLocalData('FADE_VOTE_COUNT') || 0) : 0; // 오늘 투표를 진행하지 않았지만(10번) 투표를 하고 있었을 수 있음.
 
   if (savedVoteData === null) {
     return { hasVotedToday, votingCountToday };
@@ -108,8 +108,8 @@ export const useVotingStore = create<VotingState>((set, get) => ({
         voteType: swipeDirection === 'left' ? 'FADE_OUT' : 'FADE_IN',
       };
 
-      const voteData = JSON.parse(localStorage.getItem('FADE_VOTE_DATA')!) as TLocalVoteData;
-      localStorage.setItem('FADE_VOTE_DATA', JSON.stringify({ ...voteData, voteResults: [...voteData.voteResults, newVoteResult] } as TLocalVoteData));
+      const voteData = JSON.parse(loadLocalData('FADE_VOTE_DATA')!) as TLocalVoteData;
+      saveLocalData('FADE_VOTE_DATA', JSON.stringify({ ...voteData, voteResults: [...voteData.voteResults, newVoteResult] } as TLocalVoteData));
 
       updateVoteResult(newVoteResult);
     }
@@ -120,6 +120,6 @@ export const useVotingStore = create<VotingState>((set, get) => ({
     addVotingProgress();
     addVotingCountToday();
 
-    localStorage.setItem('FADE_VOTE_COUNT', String(votingCountToday + 1));
+    saveLocalData('FADE_VOTE_COUNT', String(votingCountToday + 1));
   },
 }));

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -313,3 +313,18 @@ export function generateImagePath(imagePath: string, scale: number) {
 export function createSrcSet(imagePath: string) {
   return [1, 2, 3].map((scale) => `${generateImagePath(imagePath, scale)} ${scale}x`).join(', ');
 }
+
+export function loadLocalData(key: string) {
+  const isMockingEnabled = document.querySelector('html')!.dataset.mockingEnabled === 'true';
+  return localStorage.getItem(isMockingEnabled ? `MOCKING_${key}` : key);
+}
+
+export function saveLocalData(key: string, value: string) {
+  const isMockingEnabled = document.querySelector('html')!.dataset.mockingEnabled === 'true';
+  localStorage.setItem(isMockingEnabled ? `MOCKING_${key}` : key, value);
+}
+
+export function removeLocalData(key: string) {
+  const isMockingEnabled = document.querySelector('html')!.dataset.mockingEnabled === 'true';
+  localStorage.removeItem(isMockingEnabled ? `MOCKING_${key}` : key);
+}


### PR DESCRIPTION
### 관련된 이슈 번호를 기입해주세요.
> `close #이슈번호` 와 같은 형식으로 작성해주세요.

- close #283 

### 어떤 부분이 변경됐나요?
> 어떤 부분을 변경했는지, 무슨 이유로 코드를 변경했는지 설명해주세요.

**서비스 둘러보기 기능을 추가하였습니다.**
- 서비스 둘러보기 클릭 시 안내 모달를 노출합니다.
- 모달 바깥을 누르면 취소, CTA는 카카오 로그인과 계속 둘러보기 입니다.
- 서비스 둘리보기 시작 시 API 모킹이 시작되며, 모킹 버튼이 상단에 노출됩니다.

**모킹 버튼의 구성을 변경하였습니다.**
- 안내 문구 추가
  - API Mocking 환경에서만 동작하는 버튼임을 알립니다.
- Enabled/Disable API Mocking 버튼 삭제
  - 기존의 모킹 버튼은 실제 환경/API 모킹 환경 둘 다 있었기 때문에 항상 띄워져 있었습니다.
  - 그래서 온오프 토글 버튼이 필요했던 건데, 애초에 API 모킹 환경에서만 나타나게 되니 불필요하여 삭제하였습니다.
- Page Reload 버튼 삭제
  - 위의 이유와 같음

**localStorage 동작을 수정하였습니다.**
- API Mocking 상태와 실제 환경에서의 로컬 데이터가 같이 쓰이고 있어 이슈가 생겼습니다.
  - 투표 진행 정보, Refresh Token 등 ..
- API Mocking 상태에서 저장할 땐 MOCKING_ 이라는 Prefix가 붙여지도록 변경하였습니다. 
- 이를 위해 localStorage 동작을 관리하는 saveLocalData(), loadLoacalData(), removeLocalData() Helper Function을 작성하였습니다.

### 추가 정보 (선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.

- 모킹 상태를 전역 상태로 쓰지 않고 html의 dataset(mockingEnabled)으로 처리하였습니다.
- 모킹이 끝날 시 해당 dataset은 사라집니다.
