### PR TITLE
피드 스크롤링 애니메이션 삭제

### DIFF
--- a/src/components/FeedDetailCard.tsx
+++ b/src/components/FeedDetailCard.tsx
@@ -14,7 +14,7 @@ import { cn } from '@Utils/index';
 import { format } from 'date-fns';
 import { ko } from 'date-fns/locale';
 import { motion } from 'framer-motion';
-import { ReactNode, useEffect, useRef } from 'react';
+import { ReactNode } from 'react';
 import { MdBookmark, MdHowToVote, MdMoreHoriz, MdReport } from 'react-icons/md';
 import { useNavigate } from 'react-router-dom';
 import { BookmarkButton } from './BookmarkButton';
@@ -27,7 +27,6 @@ import { Button } from './ui/button';
 
 interface TFeedDetailCard {
   viewType?: FeedDetailDialgoViewType;
-  focus?: boolean;
   isStartAnimtionEnd?: boolean;
   onUsernameClicked?: () => void;
   onFeedEdited?: () => void;
@@ -36,9 +35,7 @@ interface TFeedDetailCard {
 
 type FeedDetailCardProps = TFeedDetailCard & TFeed;
 
-export function FeedDetailCard({ focus, viewType = 'default', isStartAnimtionEnd, onUsernameClicked, onFeedEdited, onFeedDeleted, ...feedDetail }: FeedDetailCardProps) {
-  const containerRef = useRef<HTMLDivElement>(null);
-
+export function FeedDetailCard({ viewType = 'default', onUsernameClicked, onFeedEdited, onFeedDeleted, ...feedDetail }: FeedDetailCardProps) {
   const isDefaultType = viewType === 'default';
   const isFAPType = viewType === 'fapArchiving' && TFAPArchivingFeed(feedDetail);
   const isVoteType = viewType === 'voteHistory' && isTVoteHistoryFeed(feedDetail);
@@ -52,16 +49,6 @@ export function FeedDetailCard({ focus, viewType = 'default', isStartAnimtionEnd
   const haveOutfits = outfits.length !== 0;
   const haveOutfitsMoreThanOwn = outfits.length > 1;
 
-  useEffect(() => {
-    if (containerRef.current == null) {
-      return;
-    }
-
-    if (isStartAnimtionEnd && focus) {
-      containerRef.current.scrollIntoView({ behavior: 'smooth' });
-    }
-  }, [focus, containerRef.current, isStartAnimtionEnd]);
-
   const handleFeedEdited = () => {
     onFeedEdited && onFeedEdited();
   };
@@ -71,7 +58,7 @@ export function FeedDetailCard({ focus, viewType = 'default', isStartAnimtionEnd
   };
 
   return (
-    <div ref={containerRef} className="flex h-full snap-start">
+    <div className="flex h-full snap-start">
       <section className="relative flex h-full w-full flex-col gap-3 p-5">
         {isFAPFeed && <Image src={'/assets/fap_badge.png'} className={cn('absolute right-5 top-5 size-8', { ['right-[3.75rem]']: isMine })} local />}
         {isMine && <FeedMoreButton feedDetail={feedDetail} onFeedEdited={handleFeedEdited} onFeedDeleted={handleFeedDeleted} />}

--- a/src/components/FeedDetailDialog.tsx
+++ b/src/components/FeedDetailDialog.tsx
@@ -52,20 +52,49 @@ interface TFeeds {
 type FeedsProps = TFeeds;
 
 function Feeds({ feeds, defaultViewIndex, viewType, isStartAnimtionEnd, onUsernameClicked, onFeedEdited, onFeedDeleted }: FeedsProps) {
+  const beforeFeeds = feeds
+    .slice(0, defaultViewIndex)
+    .map((feedDetail) => (
+      <FeedDetailCard
+        key={feedDetail.id}
+        {...feedDetail}
+        viewType={viewType}
+        isStartAnimtionEnd={isStartAnimtionEnd}
+        onUsernameClicked={onUsernameClicked}
+        onFeedEdited={onFeedEdited}
+        onFeedDeleted={onFeedDeleted}
+      />
+    ));
+
+  const afterFeeds = feeds
+    .slice(defaultViewIndex + 1)
+    .map((feedDetail) => (
+      <FeedDetailCard
+        key={feedDetail.id}
+        {...feedDetail}
+        viewType={viewType}
+        isStartAnimtionEnd={isStartAnimtionEnd}
+        onUsernameClicked={onUsernameClicked}
+        onFeedEdited={onFeedEdited}
+        onFeedDeleted={onFeedDeleted}
+      />
+    ));
+
+  const targetFeed = feeds[defaultViewIndex];
+
   return (
     <div id="feedList" className="h-full snap-y snap-mandatory overflow-y-scroll">
-      {feeds.map((feedDetail, index) => (
-        <FeedDetailCard
-          key={feedDetail.id}
-          {...feedDetail}
-          viewType={viewType}
-          focus={index === defaultViewIndex}
-          isStartAnimtionEnd={isStartAnimtionEnd}
-          onUsernameClicked={onUsernameClicked}
-          onFeedEdited={onFeedEdited}
-          onFeedDeleted={onFeedDeleted}
-        />
-      ))}
+      {isStartAnimtionEnd && beforeFeeds}
+      <FeedDetailCard
+        key={targetFeed.id}
+        {...targetFeed}
+        viewType={viewType}
+        isStartAnimtionEnd={isStartAnimtionEnd}
+        onUsernameClicked={onUsernameClicked}
+        onFeedEdited={onFeedEdited}
+        onFeedDeleted={onFeedDeleted}
+      />
+      {isStartAnimtionEnd && afterFeeds}
     </div>
   );
 }


### PR DESCRIPTION
### 관련된 이슈 번호를 기입해주세요.
> `close #이슈번호` 와 같은 형식으로 작성해주세요.

- close #304 

### 어떤 부분이 변경됐나요?
> 어떤 부분을 변경했는지, 무슨 이유로 코드를 변경했는지 설명해주세요.

**사진 상세 다이얼로그에서 타겟 피드를 보여주는 방식을 변경했어요.**
- 일단 넘겨주는 props을 특정 묶음이 아닌 무한스크롤로 받아온 모든 피드를 받아오도록 했습니다.
- 선택한 피드를 먼저 렌더링하고, 모달 애니메이션이 끝나면 앞뒤의 피드들을 렌더링합니다.

### 추가 정보 (선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.

- 스크롤링에 집중해서 scrollIntoView를 instant로 바꿨는데, 브라우저 단에서 처리가 되는 거라 모달의 애니메이션이 우선순위를 가지지 못해서 끊기는 현상이 발생함.
- 그러면 scrollTop으로 가져가서 계산을 해주자는 생각으로 가서, 렌더링할 피드의 위치를 알아내서 scrollTop을 지정해줌
- 하지만,, 계산한 위치와 실제 적용된 scrollTop의 값이 맞지 않았음
  - scroll-snap의 문제거나 다른 위치 문제였던 것 같음
- 위의 문제를 해결하려고 삽질을 했는데,, 떠오른 생각이 우선순위를 가지지 못해 끊기는 현상이 렌더링할 목록이 넘 많아서였다는 생각도 들었음.
- 생각의 전환으로 렌더링의 범위를 줄이자로 넘어갔고, 가상화 돔까지 적용하려고 했으나,, 이거 너무 오버 엔지니어링이라는 생각이 들었음. 고작 타겟 피드 먼저 하나 보여주자고?
- 그래서 다른 생각으로, 그렇다면 먼저 타겟 피드를 렌더링하고 나머지를 렌더링하자로 넘어감.
- insertBefore와 appenChild를 이용하면 되겠다 했는데, 이건 Node지 ReactNode 대상이 아니었음
  - 그러니까 직접 DOM을 다뤄야 하는 것.
- ReactNode에서 Node로 뽑아낼려면 낼 수 있으나,, 그것 또한 너무 돌아가는 일 같았음.
- 리액트스럽게 쓸 수 있는 방법이 뭐가 있을까 하다가,, 모달 애니메이션에 대한 상태를 넘겨주는 isStartAnimtionEnd가 떠오름.
- isStartAnimtionEnd에 따라 조건부 렌더링을 하면 되겠다! 싶었다.
- 성공! 미쳤다