### PR TITLE
모바일 환경에서 스크롤링 이슈 수정

### DIFF
--- a/src/components/FeedDetailCard.tsx
+++ b/src/components/FeedDetailCard.tsx
@@ -26,6 +26,7 @@ import { OutfitDialog } from './OutfitDialog';
 import { Button } from './ui/button';
 
 interface TFeedDetailCard {
+  feedIndex?: number;
   viewType?: FeedDetailDialgoViewType;
   isStartAnimtionEnd?: boolean;
   onUsernameClicked?: () => void;
@@ -35,7 +36,7 @@ interface TFeedDetailCard {
 
 type FeedDetailCardProps = TFeedDetailCard & TFeed;
 
-export function FeedDetailCard({ viewType = 'default', onUsernameClicked, onFeedEdited, onFeedDeleted, ...feedDetail }: FeedDetailCardProps) {
+export function FeedDetailCard({ feedIndex, viewType = 'default', onUsernameClicked, onFeedEdited, onFeedDeleted, ...feedDetail }: FeedDetailCardProps) {
   const isDefaultType = viewType === 'default';
   const isFAPType = viewType === 'fapArchiving' && TFAPArchivingFeed(feedDetail);
   const isVoteType = viewType === 'voteHistory' && isTVoteHistoryFeed(feedDetail);
@@ -45,7 +46,6 @@ export function FeedDetailCard({ viewType = 'default', onUsernameClicked, onFeed
   const { id: feedId, imageURL, isFAPFeed, isMine, outfits, styleIds } = feedDetail;
 
   const haveStyleIds = styleIds.length !== 0;
-
   const haveOutfits = outfits.length !== 0;
   const haveOutfitsMoreThanOwn = outfits.length > 1;
 
@@ -58,7 +58,7 @@ export function FeedDetailCard({ viewType = 'default', onUsernameClicked, onFeed
   };
 
   return (
-    <div className="flex h-full snap-start">
+    <div data-feed-index={feedIndex} className="flex h-full snap-start">
       <section className="relative flex h-full w-full flex-col gap-3 p-5">
         {isFAPFeed && <Image src={'/assets/fap_badge.png'} className={cn('absolute right-5 top-5 size-8', { ['right-[3.75rem]']: isMine })} local />}
         {isMine && <FeedMoreButton feedDetail={feedDetail} onFeedEdited={handleFeedEdited} onFeedDeleted={handleFeedDeleted} />}

--- a/src/components/FeedDetailDialog.tsx
+++ b/src/components/FeedDetailDialog.tsx
@@ -3,6 +3,7 @@ import { DefaultModalProps } from '@Stores/modal';
 import { TFeed } from '@Types/model';
 import { FeedDetailCard } from './FeedDetailCard';
 import { BackButton } from './ui/button';
+import { useEffect, useRef } from 'react';
 
 export type FeedDetailDialgoViewType = 'default' | 'fapArchiving' | 'voteHistory';
 
@@ -52,12 +53,15 @@ interface TFeeds {
 type FeedsProps = TFeeds;
 
 function Feeds({ feeds, defaultViewIndex, viewType, isStartAnimtionEnd, onUsernameClicked, onFeedEdited, onFeedDeleted }: FeedsProps) {
+  const feedListRef = useRef<HTMLDivElement>(null);
+
   const beforeFeeds = feeds
     .slice(0, defaultViewIndex)
-    .map((feedDetail) => (
+    .map((feedDetail, index) => (
       <FeedDetailCard
         key={feedDetail.id}
         {...feedDetail}
+        feedIndex={index}
         viewType={viewType}
         isStartAnimtionEnd={isStartAnimtionEnd}
         onUsernameClicked={onUsernameClicked}
@@ -68,10 +72,11 @@ function Feeds({ feeds, defaultViewIndex, viewType, isStartAnimtionEnd, onUserna
 
   const afterFeeds = feeds
     .slice(defaultViewIndex + 1)
-    .map((feedDetail) => (
+    .map((feedDetail, index) => (
       <FeedDetailCard
         key={feedDetail.id}
         {...feedDetail}
+        feedIndex={defaultViewIndex + index}
         viewType={viewType}
         isStartAnimtionEnd={isStartAnimtionEnd}
         onUsernameClicked={onUsernameClicked}
@@ -82,12 +87,24 @@ function Feeds({ feeds, defaultViewIndex, viewType, isStartAnimtionEnd, onUserna
 
   const targetFeed = feeds[defaultViewIndex];
 
+  useEffect(() => {
+    const mutationObserver = new MutationObserver(() => {
+      const targetFeed = feedListRef.current!.querySelector(`div[data-feed-index='${defaultViewIndex}']`)!;
+
+      targetFeed.scrollIntoView({ behavior: 'instant' });
+      mutationObserver.disconnect();
+    });
+
+    mutationObserver.observe(feedListRef.current!, { childList: true });
+  }, []);
+
   return (
-    <div id="feedList" className="h-full snap-y snap-mandatory overflow-y-scroll">
+    <div ref={feedListRef} id="feedList" className="h-full snap-y snap-mandatory overflow-y-scroll">
       {isStartAnimtionEnd && beforeFeeds}
       <FeedDetailCard
         key={targetFeed.id}
         {...targetFeed}
+        feedIndex={defaultViewIndex}
         viewType={viewType}
         isStartAnimtionEnd={isStartAnimtionEnd}
         onUsernameClicked={onUsernameClicked}

--- a/src/components/ProfileDetails.tsx
+++ b/src/components/ProfileDetails.tsx
@@ -113,6 +113,8 @@ function UserFeeds({ userId }: { userId: number }) {
     onIntersection: fetchNextPage,
   });
 
+  const allFeeds = data?.pages.flatMap(({ feeds }) => feeds.map((feed) => feed));
+
   useEffect(() => {
     !hasNextPage && disconnectObserver();
   }, [hasNextPage]);
@@ -120,7 +122,9 @@ function UserFeeds({ userId }: { userId: number }) {
   return (
     <div className="space-y-10 p-1">
       <Grid id="feedList" cols={3}>
-        {data?.pages.map((page) => page.feeds.map((feed, index) => <FeedItem key={`feed-item-${feed.id}`} {...feed} feeds={page.feeds} index={index} />))}
+        {allFeeds.map((feed, index) => (
+          <FeedItem key={`item-${feed.id}`} feeds={allFeeds} index={index} {...feed} />
+        ))}
       </Grid>
 
       {isFetchingNextPage && <SpinLoading />}

--- a/src/pages/Root/archive/components/AllArchivingView.tsx
+++ b/src/pages/Root/archive/components/AllArchivingView.tsx
@@ -58,6 +58,8 @@ function FeedList({ filters }: FeedListProps) {
     onIntersection: fetchNextPage,
   });
 
+  const allFeeds = data?.pages.flatMap(({ feeds }) => feeds.map((feed) => feed));
+
   useEffect(() => {
     !hasNextPage && disconnectObserver();
   }, [hasNextPage]);
@@ -66,7 +68,9 @@ function FeedList({ filters }: FeedListProps) {
     <div className="h-full min-h-1 flex-1 space-y-10 overflow-y-scroll">
       <div className="w-full flex-1 gap-1">
         <Grid id={`feedList`} cols={3} className="w-full">
-          {data?.pages.map(({ feeds }) => feeds.map((feed, index) => <FeedItem key={`item-${feed.id}`} feeds={feeds} index={index} {...feed} />))}
+          {allFeeds.map((feed, index) => (
+            <FeedItem key={`item-${feed.id}`} feeds={allFeeds} index={index} {...feed} />
+          ))}
         </Grid>
       </div>
 

--- a/src/pages/Root/mypage/bookmark/page.tsx
+++ b/src/pages/Root/mypage/bookmark/page.tsx
@@ -66,6 +66,8 @@ function BookmarkFeeds() {
     onIntersection: fetchNextPage,
   });
 
+  const allFeeds = data?.pages.flatMap(({ feeds }) => feeds.map((feed) => feed));
+
   useEffect(() => {
     !hasNextPage && disconnectObserver();
   }, [hasNextPage]);
@@ -73,7 +75,9 @@ function BookmarkFeeds() {
   return (
     <div className="space-y-10 p-1">
       <Grid id="feedList" cols={3}>
-        {data?.pages.map((page) => page.feeds.map((feed, index) => <FeedItem key={`feed-item-${feed.id}`} {...feed} feeds={page.feeds} index={index} />))}
+        {allFeeds.map((feed, index) => (
+          <FeedItem key={`item-${feed.id}`} feeds={allFeeds} index={index} {...feed} />
+        ))}
       </Grid>
 
       {isFetchingNextPage && <SpinLoading />}


### PR DESCRIPTION
### 관련된 이슈 번호를 기입해주세요.
> `close #이슈번호` 와 같은 형식으로 작성해주세요.

- close #307 

### 어떤 부분이 변경됐나요?
> 어떤 부분을 변경했는지, 무슨 이유로 코드를 변경했는지 설명해주세요.

**모바일 환경에서 사진 상세 모달의 스크롤링 이슈를 수정했어요.**
- 크롬에서는 노드 위에 자식이 추가되어도 스크롤 포지션을 유지하는데, 사파리에선 새로 추가된 노드로 스크롤이 가더라구요.
- 그래서 MutationObserver로 자식이 추가되면 scrollIntoView Instant를 통해 스크롤 위치를 유지했습니다.
  - 이때는 모달 애니메이션이 끝난 상태라 상관 없었음!

**사진 상세로 넘겨주는 피드들을 받아온 모든 피드로 넘겨줬어요.**
- 무한 스크롤의 pages를 flatten 하고 모든 피드를 넘겨줬습니다.

### 추가 정보 (선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.

- 사진 상세로 넘어가는 Feed Item 공통으로 빼기
