### PR TITLE
Component Prefetching 적용

### DIFF
--- a/src/pages/Root/voteFAP/page.tsx
+++ b/src/pages/Root/voteFAP/page.tsx
@@ -6,6 +6,7 @@ import { FlexibleLayout } from '@Layouts/FlexibleLayout';
 import { useAuthStore } from '@Stores/auth';
 import { useVotingStore } from '@Stores/vote';
 import { AnimatePresence, motion } from 'framer-motion';
+import { useLayoutEffect } from 'react';
 import { MdInfoOutline } from 'react-icons/md';
 import { VoteController } from './components/VoteController';
 import { VotePolicyBottomSheet } from './components/VotePolicyBottomSheet';
@@ -16,6 +17,20 @@ export default function Page() {
     leftSlot: () => <ShowVotePolicyButton />,
     rightSlot: () => <ShowNotificationButton />,
   });
+
+  useLayoutEffect(() => {
+    /** Prefetch the tab components */
+    Promise.all([
+      import('@Pages/Root/archive/page'), // 아카이브 탭
+      import('@Pages/Root/subscribe/page'), // 구독 탭
+      import('@Pages/Root/subscribe/list/page'), // 구독 목록 탭
+      import('@Pages/Root/mypage/page'), // 마이페이지 탭
+      import('@Pages/Root/mypage/feed/page'), // 마이페이지/피드
+      import('@Pages/Root/mypage/voteHistory/page'), // 마이페이지/투표내역
+      import('@Pages/Root/mypage/bookmark/page'), // 마이페이지/북마크
+      import('@Pages/Root/user/page'), // 유저 피드
+    ]);
+  }, []);
 
   return (
     <FlexibleLayout.Root className="gap-3 p-5">


### PR DESCRIPTION
아카이브 탭, 구독 탭, 마이페이지 관련 탭

### 관련된 이슈 번호를 기입해주세요.
> `close #이슈번호` 와 같은 형식으로 작성해주세요.

- close #317 

### 어떤 부분이 변경됐나요?
> 어떤 부분을 변경했는지, 무슨 이유로 코드를 변경했는지 설명해주세요.

투표 탭 컨포넌트 로드 시 Navbar에 연결된 탭 컴포넌트를 불러왔어요
- 최근 기술 아티클에서 컴포넌트 프리패칭이라는 이름으로 소개를 한 게 있어서 적용해 봐야겠다 싶었습니다.
- 천천히 뜯어보니 Lazy하게 적용한 Dynamic Import를 미리 호출하는 거더라구요.
- 해당 아티클에선 컴포넌트에 `prefetch()`라는 메소드를 추가해주고 호출하는 방식이었는데, 굳이 그럴 필요가 있나? 싶어서 저는 직접 호출했습니다.
- DOM에 그려지기 전에 비동기로 탭 컴포넌트를 불러옵니다.
- 각 탭 컴포넌트에 들어갈 때 '탭 컴포넌트를 불러오는' Skeleton UI가 제거됨으로써 UX를 생각했습니다.

![image](https://github.com/user-attachments/assets/dffa0dad-fc78-4fd8-82a1-4c675e7307c7)

### 추가 정보 (선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.

- 해당 없음
