### PR TITLE
⚡️ 이미지 크롭 리렌더링으로 인한 Throttling 해결

### DIFF
--- a/src/components/forms/bon/_components/ImageCropperModal.tsx
+++ b/src/components/forms/bon/_components/ImageCropperModal.tsx
@@ -1,68 +1,80 @@
 import { Button } from '@Components/ui/button';
+import { useToastActions } from '@Hooks/toast';
 import { DefaultModalProps } from '@Stores/modal';
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { Cropper, ReactCropperElement } from 'react-cropper';
 import { MdChevronLeft } from 'react-icons/md';
+import { VscLoading } from 'react-icons/vsc';
 import './cropper.css';
 
 type ImageCropperModalProps = DefaultModalProps<unknown, { imageFile: File }>;
 
 export function ImageCropperModal({ imageFile, onClose }: ImageCropperModalProps) {
-  const cropperRef = useRef<ReactCropperElement>(null);
-  const croppedDataBlob = useRef<Blob>(new Blob());
+  const { showToast } = useToastActions();
+  const [doesConverting, setDoesConverting] = useState(false);
 
+  const cropperRef = useRef<ReactCropperElement>(null);
   const fileImageURL = URL.createObjectURL(imageFile);
 
   useEffect(() => {
-    return () => {
-      URL.revokeObjectURL(fileImageURL);
-    };
+    return () => URL.revokeObjectURL(fileImageURL);
   });
 
-  function dataURLtoBlob(dataURL: string) {
-    const arr = dataURL.split(',');
-    const matches = arr[0].match(/:(.*?);/);
-    const mime = matches && matches.length >= 2 ? matches[1] : null;
+  async function dataURLtoBlob(dataURL: string) {
+    return new Promise<Blob>((resolve, reject) => {
+      const arr = dataURL.split(',');
+      const matches = arr[0].match(/:(.*?);/);
+      const mime = matches && matches.length >= 2 ? matches[1] : null;
 
-    // MIME 타입이 없을 때 크롭 리셋
-    if (!mime) {
-      const cropperInstance = cropperRef.current?.cropper;
-      cropperInstance?.reset();
-      return;
-    }
+      // MIME 타입이 없을 때 크롭 리셋
+      if (!mime) {
+        const cropperInstance = cropperRef.current!.cropper;
+        cropperInstance.reset();
+        reject();
+        return;
+      }
 
-    const bstr = atob(arr[1]);
-    let n = bstr.length;
-    const u8arr = new Uint8Array(n);
+      const bstr = atob(arr[1]);
+      let n = bstr.length;
+      const u8arr = new Uint8Array(n);
 
-    while (n--) {
-      u8arr[n] = bstr.charCodeAt(n);
-    }
-    return new Blob([u8arr], { type: mime });
+      while (n--) {
+        u8arr[n] = bstr.charCodeAt(n);
+      }
+
+      resolve(new Blob([u8arr], { type: mime }));
+    });
   }
 
-  const handleCrop = () => {
-    const cropper = cropperRef?.current?.cropper;
-    const croppedDataURL = cropper?.getCroppedCanvas().toDataURL();
+  const handleApplyClick = () => {
+    const cropper = cropperRef.current!.cropper;
+    const croppedDataURL = cropper.getCroppedCanvas().toDataURL();
 
-    if (croppedDataBlob.current !== undefined) {
-      croppedDataBlob.current = dataURLtoBlob(croppedDataURL!)!;
-    }
+    setDoesConverting(true);
+
+    dataURLtoBlob(croppedDataURL)
+      .then((convertedBlob) => onClose(convertedBlob))
+      .catch(() => {
+        showToast({
+          type: 'error',
+          title: '이미지 크기 조절 오류',
+          description: '다시 시도해주세요.',
+        });
+
+        setDoesConverting(false);
+      });
   };
 
   return (
     <div className="relative flex flex-1 flex-col">
       <div className="flex flex-row justify-between p-2">
-        <Button variants="ghost" size="icon" onClick={() => onClose()}>
+        <Button variants="ghost" size="icon" onClick={() => onClose()} disabled={doesConverting}>
           <MdChevronLeft className="size-6" />
         </Button>
 
-        <Button
-          variants="ghost"
-          onClick={() => {
-            onClose(croppedDataBlob.current);
-          }}>
-          확인
+        <Button variants="ghost" onClick={handleApplyClick} disabled={doesConverting}>
+          {!doesConverting && '확인'}
+          {doesConverting && <VscLoading className="animate-spin" />}
         </Button>
       </div>
 
@@ -79,7 +91,6 @@ export function ImageCropperModal({ imageFile, onClose }: ImageCropperModalProps
         autoCropArea={1}
         checkOrientation={false}
         guides={true}
-        crop={handleCrop}
         ref={cropperRef}
       />
     </div>


### PR DESCRIPTION
### 관련된 이슈 번호를 기입해주세요.
> `close #이슈번호` 와 같은 형식으로 작성해주세요.

- close #333 

### 어떤 부분이 변경됐나요?
> 어떤 부분을 변경했는지, 무슨 이유로 코드를 변경했는지 설명해주세요.

**이미지 크롭 쓰로틀링 현상을 해결했어요**
- react-cropper의 Cropper는 크롭이 진행 중일 때 crop 이벤트를 일으킵니다.
- 이때, 해당 핸들러에서 계속 data Blob을 생성하고 있어 Throttling 현상이 발생했습니다.
- 해당 로직은 크롭 진행 중에 필요하지 않으므로, 확인 버튼을 눌렀을 때로 옮겼습니다.

**Data Blob 생성에 대한 로딩을 추가했어요**
- 핸드폰 사진은 해상도 및 용량이 커서 Data Blob을 만드는 데 시간이 걸리는 것을 확인하였습니다.
- 이에 Data Blob을 반환하는 로직을 Promise로 변경하여 비동기 처리하였습니다.
- 비동기 시간 동안 로딩 상태를 표시합니다.

### 추가 정보 (선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.

- 해당 없음
